### PR TITLE
Support unary/binary/inplace operators

### DIFF
--- a/symbolic_trace/opcode_translator/executor/variables.py
+++ b/symbolic_trace/opcode_translator/executor/variables.py
@@ -198,9 +198,12 @@ class ConstantVariable(VariableTracker):
         return var
 
     def __sub__(self, other):
-        if not isinstance(other, (ConstantVariable, TensorVariable)):
+        if not isinstance(other, ConstantVariable):
             return NotImplemented
-        return self.graph.call_tensor_method("__sub__", self, other)
+        var = VariableTrackerFactory.from_value(
+            self.value - other.value, None, tracker=DummyTracker([self, other])
+        )
+        return var
 
     @VariableTrackerFactory.register_from_value
     def from_value(
@@ -264,6 +267,55 @@ class TensorVariable(VariableTracker):
         if not isinstance(other, (ConstantVariable, TensorVariable)):
             return NotImplemented
         return self.graph.call_tensor_method("__rsub__", self, other)
+
+    def __pow__(self, other):
+        if not isinstance(other, (ConstantVariable, TensorVariable)):
+            return NotImplemented
+        return self.graph.call_tensor_method("__pow__", self, other)
+
+    def __matmul__(self, other):
+        if not isinstance(other, (ConstantVariable, TensorVariable)):
+            return NotImplemented
+        return self.graph.call_tensor_method("__matmul__", self, other)
+
+    def __floordiv__(self, other):
+        if not isinstance(other, (ConstantVariable, TensorVariable)):
+            return NotImplemented
+        return self.graph.call_tensor_method("__floordiv__", self, other)
+
+    def __truediv__(self, other):
+        if not isinstance(other, (ConstantVariable, TensorVariable)):
+            return NotImplemented
+        return self.graph.call_tensor_method("__truediv__", self, other)
+
+    def __mod__(self, other):
+        if not isinstance(other, (ConstantVariable, TensorVariable)):
+            return NotImplemented
+        return self.graph.call_tensor_method("__mod__", self, other)
+
+    def __and__(self, other):
+        if not isinstance(other, (ConstantVariable, TensorVariable)):
+            return NotImplemented
+        return self.graph.call_tensor_method("__and__", self, other)
+
+    def __or__(self, other):
+        if not isinstance(other, (ConstantVariable, TensorVariable)):
+            return NotImplemented
+        return self.graph.call_tensor_method("__or__", self, other)
+
+    def __xor__(self, other):
+        if not isinstance(other, (ConstantVariable, TensorVariable)):
+            return NotImplemented
+        return self.graph.call_tensor_method("__xor__", self, other)
+
+    # Paddle variable do not have inplace operators. For example when call `y **= x`, will call var.__pow__.
+    # If inplace operator do not impl, it will try to call non-inplace operator, so we do not impl inplace magic method here
+
+    def __neg__(self):
+        return self.graph.call_tensor_method("__neg__", self)
+
+    def __invert__(self):
+        return self.graph.call_tensor_method("__invert__", self)
 
     def __repr__(self) -> str:
         return f"TensorVariable{self.value.meta}"

--- a/tests/test_executor/test_14_operators.py
+++ b/tests/test_executor/test_14_operators.py
@@ -203,13 +203,3 @@ class TestExecutor(TestCaseBase):
 
 if __name__ == "__main__":
     unittest.main()
-
-
-# Instructions:
-#
-# ops...
-
-# Variables:
-# ConstantVariable
-# NestedUserFunctionVariable
-# TensorVariable

--- a/tests/test_executor/test_14_operators.py
+++ b/tests/test_executor/test_14_operators.py
@@ -1,7 +1,8 @@
-from __future__ import annotations
+import unittest
+
+from test_case_base import TestCaseBase
 
 import paddle
-from symbolic_trace import symbolic_trace
 
 
 def unary_positive(x: int):
@@ -154,45 +155,55 @@ def inplace_xor(x: paddle.Tensor, y: paddle.Tensor):
     return x
 
 
-a = paddle.to_tensor(1)
-b = paddle.to_tensor(True)
-c = paddle.to_tensor(3)
-d = paddle.to_tensor(4)
-e = paddle.to_tensor([[1, 2], [3, 4], [5, 6]], dtype='float32')
-f = paddle.to_tensor([[1, 2, 3], [4, 5, 6]], dtype='float32')
-g = paddle.to_tensor(False)
-symbolic_trace(unary_positive)(1)
-symbolic_trace(unary_negative)(a)
-symbolic_trace(unary_not)(b)
-symbolic_trace(unary_invert)(b)
+class TestExecutor(TestCaseBase):
+    def test_simple(self):
+        a = paddle.to_tensor(1)
+        b = paddle.to_tensor(True)
+        c = paddle.to_tensor(3)
+        d = paddle.to_tensor(4)
+        e = paddle.to_tensor([[1, 2], [3, 4], [5, 6]], dtype='float32')
+        f = paddle.to_tensor([[1, 2, 3], [4, 5, 6]], dtype='float32')
+        g = paddle.to_tensor(False)
 
-symbolic_trace(binary_power)(c, d)
-symbolic_trace(binary_multiply)(c, d)
-symbolic_trace(binary_matrix_multiply)(e, f)
-symbolic_trace(binary_floor_divide)(c, d)
-symbolic_trace(binary_true_divide)(c, d)
-symbolic_trace(binary_modulo)(c, d)
-symbolic_trace(binary_add)(c, d)
-symbolic_trace(binary_subtract)(c, d)
-symbolic_trace(binary_lshift)(10, 2)
-symbolic_trace(binary_rshift)(10, 1)
-symbolic_trace(binary_and)(b, g)
-symbolic_trace(binary_or)(b, g)
-symbolic_trace(binary_xor)(b, g)
+        # self.assert_results(unary_positive, 1)
+        self.assert_results(unary_negative, a)
+        # self.assert_results(unary_not, b)
+        self.assert_results(unary_invert, b)
 
-symbolic_trace(inplace_power)(c, d)
-symbolic_trace(inplace_multiply)(c, d)
-symbolic_trace(inplace_matrix_multiply)(e, f)
-symbolic_trace(inplace_floor_divide)(c, d)
-symbolic_trace(inplace_true_divide)(c, d)
-symbolic_trace(inplace_modulo)(c, d)
-symbolic_trace(inplace_add)(c, d)
-symbolic_trace(inplace_subtract)(c, d)
-symbolic_trace(inplace_lshift)(10, 2)
-symbolic_trace(inplace_rshift)(10, 1)
-symbolic_trace(inplace_and)(b, g)
-symbolic_trace(inplace_or)(b, g)
-symbolic_trace(inplace_xor)(b, g)
+        self.assert_results(binary_power, c, d)
+        self.assert_results(binary_multiply, c, d)
+        self.assert_results(binary_matrix_multiply, e, f)
+        self.assert_results(binary_floor_divide, c, d)
+        # check error
+        # self.assert_results(binary_true_divide, c, d)
+        self.assert_results(binary_modulo, c, d)
+        self.assert_results(binary_add, c, d)
+        self.assert_results(binary_subtract, c, d)
+        # self.assert_results(binary_lshift, 10, 2)
+        # self.assert_results(binary_rshift, 10, 1)
+        self.assert_results(binary_and, b, g)
+        self.assert_results(binary_or, b, g)
+        self.assert_results(binary_xor, b, g)
+
+        self.assert_results(inplace_power, c, d)
+        self.assert_results(inplace_multiply, c, d)
+        self.assert_results(inplace_matrix_multiply, e, f)
+        self.assert_results(inplace_floor_divide, c, d)
+        # check error
+        # self.assert_results(inplace_true_divide, c, d)
+        self.assert_results(inplace_modulo, c, d)
+        self.assert_results(inplace_add, c, d)
+        self.assert_results(inplace_subtract, c, d)
+        # self.assert_results(inplace_lshift, 10, 2)
+        # self.assert_results(inplace_rshift, 10, 1)
+        self.assert_results(inplace_and, b, g)
+        self.assert_results(inplace_or, b, g)
+        self.assert_results(inplace_xor, b, g)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
 
 # Instructions:
 #


### PR DESCRIPTION
统一了unary/binary/inplace 相关字节码的定义方式，支持了24个相关字节码

遗留了下面几个TODO:
1. test_14_operator单测中有几个case还没有支持，可以分成一下几类
    - unary_positive、binary_lshift、binary_rshift、inplace_lshift、inplace_rshift：这几个case的输出结果是非tensor类型的，complie时还不支持这种情况，需要@晓健扩展complie功能后再支持这几个测试case
    - binary_true_divide、inplace_true_divide：这两个case动态图和动转静结果不一致，动态图下`tensor([3]) / tensor([4])`的结果是tensor([0.75])，而动转静的结果是tensor([0])。下面的代码可以复现，需要修复该动静不一致的问题后再支持
      ```python
      import paddle
      # @paddle.jit.to_static
      def fn(x, y):
          z = x / y
          return z
      
      x = paddle.to_tensor([3])
      y = paddle.to_tensor([4])
      
      print(fn(x, y))
      ```
    - unary_not：paddle variable没有实现__bool__方法，所以并不支持not var这样的操作。遇到not var的情况似乎应该触发fallback？

2. ConstantVariable和TensorVariable中有大量实现相同的魔法函数，可以统一他们的定义方式
