### PR TITLE
add multiple args support for `start_compile`

### DIFF
--- a/symbolic_trace/opcode_translator/executor/function_graph.py
+++ b/symbolic_trace/opcode_translator/executor/function_graph.py
@@ -96,8 +96,12 @@ class FunctionGraph:
 
         return compose_guards(guards)
 
-    def start_compile(self, ret_var: VariableTracker):
-        ret_items = ret_var.flatten_items()
+    def start_compile(self, *ret_vars: VariableTracker):
+        ret_items = [
+            ret_item
+            for ret_var in ret_vars
+            for ret_item in ret_var.flatten_items()
+        ]
         tensor_items = self._find_tensor_outputs(ret_items)
         compiled_fn, statment_ir = self.sir_ctx.compile_fn(
             [tensor_var.value for tensor_var in tensor_items]
@@ -126,7 +130,8 @@ class FunctionGraph:
         for tensor_var in tensor_items:
             self.pycode_gen.gen_store_fast(tensor_var.out_var_name)
         # restore the outputs.
-        ret_var.reconstruct(self.pycode_gen)
+        for ret_var in ret_vars:
+            ret_var.reconstruct(self.pycode_gen)
 
         # deal side effect
         # TODO(xiongkun): add side effect handle

--- a/symbolic_trace/opcode_translator/executor/function_graph.py
+++ b/symbolic_trace/opcode_translator/executor/function_graph.py
@@ -130,7 +130,7 @@ class FunctionGraph:
         for tensor_var in tensor_items:
             self.pycode_gen.gen_store_fast(tensor_var.out_var_name)
         # restore the outputs.
-        for ret_var in reversed(ret_vars):
+        for ret_var in ret_vars:
             ret_var.reconstruct(self.pycode_gen)
 
         # deal side effect

--- a/symbolic_trace/opcode_translator/executor/function_graph.py
+++ b/symbolic_trace/opcode_translator/executor/function_graph.py
@@ -130,7 +130,7 @@ class FunctionGraph:
         for tensor_var in tensor_items:
             self.pycode_gen.gen_store_fast(tensor_var.out_var_name)
         # restore the outputs.
-        for ret_var in ret_vars:
+        for ret_var in reversed(ret_vars):
             ret_var.reconstruct(self.pycode_gen)
 
         # deal side effect


### PR DESCRIPTION
为 `start_compile` 支持传入多个参数

比如

```python
start_compile(a, b, c)
# 会依次放到栈上，也就是 c 在栈顶，之后依次是 b、a，如果想要 LOAD，是反着来的
```

对于 if 触发 Fallback 场景，可以

```python
# if cond:
#     var_0
#     var_1
# else:
#     var_2

start_compile(cond, var_0, var_1, var_2)
for i in range(3):
    gen_pop_top()
cond.reconstruct()
```

对于 print 等 CALL_FUNCTION 触发的场景，可以

```python
# print(var_0, var_1, var_2)

start_compile(var_0, var_1, var_2)
gen_call_function() # 直接 CALL_FUNCTION 即可，因为 CALL_FUNCTION 时栈上本来就是倒序的
```