### PR TITLE
Support more jump fallback case

### DIFF
--- a/symbolic_trace/opcode_translator/executor/opcode_executor.py
+++ b/symbolic_trace/opcode_translator/executor/opcode_executor.py
@@ -794,25 +794,35 @@ class OpcodeExecutor(OpcodeExecutorBase):
         for _ in inputs_var:
             self._graph.pycode_gen.gen_pop_top()
 
-        self._graph.pycode_gen.gen_load_object(if_fn, if_fn.__code__.co_name)
-        insert_index = len(self._graph.pycode_gen._instructions) - 1
-        for name in if_inputs:
-            self._locals[name].reconstruct(self._graph.pycode_gen)
-        self._graph.pycode_gen.gen_call_function(
-            argc=if_fn.__code__.co_argcount
-        )
-        self._graph.pycode_gen.gen_return()
+        if if_fn is not None:
+            self._graph.pycode_gen.gen_load_object(
+                if_fn, if_fn.__code__.co_name
+            )
+            insert_index = len(self._graph.pycode_gen._instructions) - 1
+            for name in if_inputs:
+                self._locals[name].reconstruct(self._graph.pycode_gen)
+            self._graph.pycode_gen.gen_call_function(
+                argc=if_fn.__code__.co_argcount
+            )
+            self._graph.pycode_gen.gen_return()
+        else:
+            insert_index = len(self._graph.pycode_gen._instructions) - 1
+            self._graph.pycode_gen.gen_return()
 
-        self._graph.pycode_gen.gen_load_object(
-            else_fn, else_fn.__code__.co_name
-        )
-        jump_to = self._graph.pycode_gen._instructions[-1]
-        for name in else_inputs:
-            self._locals[name].reconstruct(self._graph.pycode_gen)
-        self._graph.pycode_gen.gen_call_function(
-            argc=else_fn.__code__.co_argcount
-        )
-        self._graph.pycode_gen.gen_return()
+        if else_fn is not None:
+            self._graph.pycode_gen.gen_load_object(
+                else_fn, else_fn.__code__.co_name
+            )
+            jump_to = self._graph.pycode_gen._instructions[-1]
+            for name in else_inputs:
+                self._locals[name].reconstruct(self._graph.pycode_gen)
+            self._graph.pycode_gen.gen_call_function(
+                argc=else_fn.__code__.co_argcount
+            )
+            self._graph.pycode_gen.gen_return()
+        else:
+            self._graph.pycode_gen.gen_return()
+            jump_to = self._graph.pycode_gen._instructions[-1]
 
         self._graph.pycode_gen._insert_instr(
             insert_index, instr.opname, jump_to=jump_to

--- a/symbolic_trace/opcode_translator/executor/pycode_generator.py
+++ b/symbolic_trace/opcode_translator/executor/pycode_generator.py
@@ -170,6 +170,8 @@ class PyCodeGen:
 
     def gen_resume_fn_at(self, index):
         self._instructions = get_instructions(self._origin_code)
+        if self._instructions[index].opname == 'RETURN_VALUE':
+            return None, set()
         inputs = read_write_analysis(self._instructions, index)
         self._instructions = [
             gen_instr('JUMP_ABSOLUTE', jump_to=self._instructions[index])

--- a/tests/test_executor/test_11_jumps.py
+++ b/tests/test_executor/test_11_jumps.py
@@ -57,18 +57,15 @@ class TestExecutor(TestCaseBase):
         self.assert_results(pop_jump_if_true, True, False, a)
 
     def test_fallback(self):
-        return
-        # self.assert_results(pop_jump_if_false, true_tensor, a)
-        # self.assert_results(jump_if_false_or_pop, true_tensor, a)
-        # self.assert_results(jump_if_true_or_pop, false_tensor, a)
-        # self.assert_results(pop_jump_if_true, true_tensor, false_tensor, a)
-        # self.assert_results(jump_absolute, 5, a)
-
-        # TODO(@wangzhen): fallback errors.
-        # self.assert_results(pop_jump_if_false, false_tensor, a)
-        # self.assert_results(jump_if_false_or_pop, false_tensor, a)
-        # self.assert_results(jump_if_true_or_pop, false_tensor, a)
-        # self.assert_results(pop_jump_if_true, true_tensor, false_tensor, a)
+        self.assert_results(pop_jump_if_false, true_tensor, a)
+        self.assert_results(jump_if_false_or_pop, true_tensor, a)
+        self.assert_results(jump_if_true_or_pop, false_tensor, a)
+        self.assert_results(pop_jump_if_true, true_tensor, false_tensor, a)
+        self.assert_results(jump_absolute, 5, a)
+        self.assert_results(pop_jump_if_false, false_tensor, a)
+        self.assert_results(jump_if_false_or_pop, false_tensor, a)
+        self.assert_results(jump_if_true_or_pop, false_tensor, a)
+        self.assert_results(pop_jump_if_true, true_tensor, false_tensor, a)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
以jump_if_true_or_pop单测case为例
```
def jump_if_true_or_pop(x: bool, y: paddle.Tensor):
    return x or (y + 1)
```

原始函数的字节码:
```
        0 LOAD_FAST                0 (x)
        2 JUMP_IF_TRUE_OR_POP     10
        4 LOAD_FAST                1 (y)
        6 LOAD_CONST               1 (1)
        8 BINARY_ADD
  >>   10 RETURN_VALUE
```
eval frame改写后的字节码:
```
         0 LOAD_GLOBAL                 0 (dummy_func)
         2 BUILD_TUPLE                   0
         4 CALL_FUNCTION              1
         6 UNPACK_SEQUENCE            0
         8 LOAD_FAST                    0 (x)
        10 LOAD_FAST                   1 (y)
        12 POP_TOP
        14 JUMP_IF_TRUE_OR_POP     24
        16 LOAD_GLOBAL               1 (__resume_fn_0)
        18 LOAD_FAST                    1 (y)
        20 CALL_FUNCTION            1
        22 RETURN_VALUE
   >>   24 RETURN_VALUE
```