### PR TITLE
add var args support to inline executor

### DIFF
--- a/symbolic_trace/opcode_translator/executor/pycode_generator.py
+++ b/symbolic_trace/opcode_translator/executor/pycode_generator.py
@@ -223,7 +223,8 @@ class PyCodeGen:
         self._add_instr("LOAD_FAST", arg=idx, argval=name)
 
     def gen_load_attr(self, name: str):
-        assert name in self._code_options["co_names"]
+        if name not in self._code_options['co_names']:
+            self._code_options["co_names"].append(name)
         idx = self._code_options["co_names"].index(name)
         self._add_instr("LOAD_ATTR", arg=idx, argval=name)
 

--- a/symbolic_trace/opcode_translator/executor/variables.py
+++ b/symbolic_trace/opcode_translator/executor/variables.py
@@ -618,6 +618,9 @@ class TensorMethodVariable(CallableVariable):
         if inspect.ismethod(value) and isinstance(
             value.__self__, paddle.Tensor
         ):
+            # NOTE(SigureMo): Since the method_self need method_var as the obj
+            # of the tracker, we need to temporarily set the tracker of method_self
+            # to DummyTracker, and set it to GetAttrTracker after method_var is created.
             method_self = TensorVariable(
                 value.__self__, graph, DummyTracker([])
             )

--- a/symbolic_trace/opcode_translator/executor/variables.py
+++ b/symbolic_trace/opcode_translator/executor/variables.py
@@ -642,23 +642,8 @@ class FunctionVariable(CallableVariable):
         super().__init__(graph, tracker)
         self.value = func
 
-    def setup_default_args(self, args, kwargs):
-        argspec = inspect.getfullargspec(self.value)
-        n_total_args = len(argspec.args) if argspec.args else 0
-        n_default_args = len(argspec.defaults) if argspec.defaults else 0
-        default_arg_offset = n_total_args - n_default_args
-        for idx in range(len(args), n_total_args):
-            arg_name = argspec.args[idx]
-            if arg_name not in kwargs.keys():
-                default_arg_idx = idx - default_arg_offset
-                assert default_arg_idx >= 0
-                default_val = argspec.defaults[default_arg_idx]
-                kwargs[arg_name] = default_val
-
     def call_function(self, *args, **kwargs) -> VariableTracker:
         from .opcode_inline_executor import OpcodeInlineExecutor
-
-        self.setup_default_args(args, kwargs)
 
         if self.value is ASSERT:
             return self.value(args[0].value)

--- a/tests/test_executor/test_06_call_function.py
+++ b/tests/test_executor/test_06_call_function.py
@@ -47,13 +47,78 @@ def foo_4(x: paddle.Tensor):
     return m
 
 
+def fn_with_varargs_and_kwargs(x, *args, **kwargs):
+    return (
+        x
+        + args[0]
+        + args[1]
+        - args[2]
+        + kwargs['a'] * kwargs['b'] / kwargs['c']
+    )
+
+
+def foo_5(x: paddle.Tensor):
+    m = x + 1
+    m = fn_with_varargs_and_kwargs(
+        m, x + 1, x + 2, x + 3, a=x + 4, b=x + 5, c=x + 6
+    )
+    return m
+
+
+def fn_with_default_value(x, y=1, z=2):
+    return x + y + z
+
+
+def foo_6(x: paddle.Tensor):
+    m = x + 1
+    m = fn_with_default_value(m, m + 10)
+    m = fn_with_default_value(m + 42)
+    return m
+
+
+def fn_with_default_value_and_varargs_kwargs(x, y=1, *args, **kwargs):
+    return x + y + args[0] + kwargs['a']
+
+
+def foo_7(x: paddle.Tensor):
+    m = x + 1
+    m = fn_with_default_value_and_varargs_kwargs(m, m + 1, m + 2, a=m + 3)
+    return m
+
+
+def fn_with_default_value_and_varargs_kwargs_kwonly_1(
+    x, y=1, *args, z, **kwargs
+):
+    return x + y + args[0] + kwargs['a'] + z
+
+
+def fn_with_default_value_and_varargs_kwargs_kwonly_2(
+    x, y=1, *args, z=10, **kwargs
+):
+    return x + y + args[0] + kwargs['a'] + z
+
+
+def foo_8(x: paddle.Tensor):
+    m = x + 1
+    m = fn_with_default_value_and_varargs_kwargs_kwonly_1(
+        m, m + 1, m + 2, a=m + 3, z=m + 4
+    )
+    m = fn_with_default_value_and_varargs_kwargs_kwonly_2(
+        m, m + 1, m + 2, a=m + 3
+    )
+    return m
+
+
 class TestExecutor(TestCaseBase):
     def test_simple(self):
         self.assert_results(foo_1, paddle.to_tensor(2))
-        self.assert_results(foo_2, paddle.to_tensor(2))
-        self.assert_results(foo_3, paddle.to_tensor(2))
-        # TODO: FunctionConstTracker is missing.
-        # self.assert_results(foo_4, paddle.to_tensor(2))
+        self.assert_results(foo_2, paddle.to_tensor(3))
+        self.assert_results(foo_3, paddle.to_tensor(4))
+        self.assert_results(foo_4, paddle.to_tensor(5))
+        self.assert_results(foo_5, paddle.to_tensor(6))
+        self.assert_results(foo_6, paddle.to_tensor(7))
+        self.assert_results(foo_7, paddle.to_tensor(8))
+        self.assert_results(foo_8, paddle.to_tensor(9))
 
 
 if __name__ == "__main__":

--- a/tests/test_executor/test_18_tensor_method.py
+++ b/tests/test_executor/test_18_tensor_method.py
@@ -21,6 +21,10 @@ def tensor_method_call_2(a: paddle.Tensor, b: paddle.Tensor):
     return i
 
 
+def tensor_method_passed_by_user(a: paddle.Tensor, func: paddle.Tensor):
+    return func(a)
+
+
 class TestTensorMethod(TestCaseBase):
     def test_tensor_method_1(self):
         x = paddle.rand([10])
@@ -32,6 +36,11 @@ class TestTensorMethod(TestCaseBase):
         x = paddle.rand([42])
         y = paddle.rand([42])
         self.assert_results(tensor_method_call_2, x, y)
+
+    def test_tensor_method_passed_by_user(self):
+        x = paddle.rand([42])
+        y = paddle.rand([42])
+        self.assert_results(tensor_method_passed_by_user, x, y.add)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
为 OpcodeInlineExecutor 参数绑定处（`_prepare_locals`）支持了变长参数（`*args`、`**kwargs`）

并解决了 #69 comment 中的问题～