### PR TITLE
fix wrong index calculation caused by `list.index`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,4 @@ ignore = [
 
 [tool.ruff.per-file-ignores]
 "tests/test_generator.py" = ["UP028"]
+"tests/test_executor/test_dup_top.py" = ["E712"]

--- a/symbolic_trace/opcode_translator/executor/pycode_generator.py
+++ b/symbolic_trace/opcode_translator/executor/pycode_generator.py
@@ -199,9 +199,9 @@ class PyCodeGen:
         return fn, inputs
 
     def gen_load_const(self, value):
-        # Python list.index will find equal values, i.e. `a == b` returns the value of True,
-        # but the result of `1 == True` is True, which will result in an incorrect index
-        # for the calculation. To avoid this problem, id is used here for comparison.
+        # Python `list.index` will find an item equal to query, i.e. `query == item`
+        # returns a value of True. Since `1 == True`, this will result in an incorrect
+        # index. To avoid this problem, we use id for comparison.
         if not list_contain_by_id(self._code_options["co_consts"], value):
             self._code_options["co_consts"].append(value)
         idx = list_find_index_by_id(self._code_options["co_consts"], value)

--- a/symbolic_trace/utils/__init__.py
+++ b/symbolic_trace/utils/__init__.py
@@ -13,6 +13,8 @@ from .utils import (
     is_paddle_api,
     is_proxy_tensor,
     is_strict_mode,
+    list_contain_by_id,
+    list_find_index_by_id,
     log,
     log_do,
     map_if,
@@ -43,4 +45,6 @@ __all__ = [
     "paddle_tensor_method",
     "ASSERT",
     "ResumeFnNameFactory",
+    "list_contain_by_id",
+    "list_find_index_by_id",
 ]

--- a/symbolic_trace/utils/utils.py
+++ b/symbolic_trace/utils/utils.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import inspect
 import os
 import time
+from typing import Any
 from weakref import WeakValueDictionary
 
 from frozendict import frozendict
@@ -194,3 +197,11 @@ def is_strict_mode():
 
 def ASSERT(input: bool):
     assert input
+
+
+def list_find_index_by_id(li: list[Any], item: Any) -> int:
+    return [id(it) for it in li].index(id(item))
+
+
+def list_contain_by_id(li: list[Any], item: Any) -> int:
+    return id(item) in [id(it) for it in li]

--- a/tests/test_executor/test_dup_top.py
+++ b/tests/test_executor/test_dup_top.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+
+from test_case_base import TestCaseBase
+
+import paddle
+
+
+def func_dup_top_1():
+    return True == True != False
+
+
+def func_dup_top_2(x):
+    y = x + 1
+    return True == True != False
+
+
+def func_dup_top_two(x: list[paddle.Tensor]):
+    x[0] += x[1]
+    return x
+
+
+class TestDupTop(TestCaseBase):
+    def test_dup_top(self):
+        self.assert_results(func_dup_top_1)
+        self.assert_results(func_dup_top_2, paddle.to_tensor(1.0))
+        # TODO: fix this after we support side effect
+        # self.assert_results(
+        #     func_dup_top_two, [paddle.to_tensor(1.0), paddle.to_tensor(2.0)]
+        # )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
修复 gen_load_const 里 `list.index` 使用问题，比如如下情况：

```
co_consts = [None, 1, True]
co_consts.index(True) # 1
# 这里返回的是 1，因为 list.index 比较的是「equal」，见
# https://docs.python.org/3/tutorial/datastructures.html
# 而 1 == True，因此这里会计算得到错误的下标
# 为了避免这一问题，这里改用 id 来匹配
```

这里只有 co_consts 有这一问题，co_names、co_varnames 都是字符串比较，没有这一问题，无需修改