### PR TITLE
skip `sre_compile` and `sre_parse`

### DIFF
--- a/symbolic_trace/opcode_translator/executor/variables.py
+++ b/symbolic_trace/opcode_translator/executor/variables.py
@@ -105,7 +105,7 @@ class VariableBase:
     """
 
     tracker: Tracker
-    name_generator = NameGenerator("tracker_")
+    name_generator = NameGenerator("object_")
 
     def __init__(self, tracker: Tracker):
         self.tracker = tracker

--- a/symbolic_trace/opcode_translator/skip_files.py
+++ b/symbolic_trace/opcode_translator/skip_files.py
@@ -19,6 +19,8 @@ import random
 import re
 import selectors
 import signal
+import sre_compile
+import sre_parse
 import sys
 import tempfile
 import threading
@@ -67,6 +69,8 @@ skip_file_names = {
         random,
         re,
         selectors,
+        sre_compile,
+        sre_parse,
         signal,
         tempfile,
         threading,

--- a/symbolic_trace/symbolic/statement_ir.py
+++ b/symbolic_trace/symbolic/statement_ir.py
@@ -177,7 +177,9 @@ class StatementIRFactory:
 
     def clear(self):
         want_clear = [
-            key for key in self.cache.keys() if key.startswith("SIR_")
+            key
+            for key in self.cache.keys()
+            if self.name_generator.match_name(key)
         ]
         for key in want_clear:
             del self.cache[key]

--- a/symbolic_trace/utils/utils.py
+++ b/symbolic_trace/utils/utils.py
@@ -42,6 +42,9 @@ class NameGenerator:
         self.counter += 1
         return name
 
+    def match_name(self, name: str) -> bool:
+        return name.startswith(self.prefix)
+
 
 @Singleton
 class ResumeFnNameFactory:


### PR DESCRIPTION
- 在 `skip_files` 添加 `sre_compile` 和 `sre_parse`，以确保最新版 Paddle 也能跑通
- 调整部分 NameGenerator 相关代码