### PR TITLE
use graphviz to visualize trackers

### DIFF
--- a/symbolic_trace/opcode_translator/executor/function_graph.py
+++ b/symbolic_trace/opcode_translator/executor/function_graph.py
@@ -11,7 +11,7 @@ from ...infer_meta import InferMetaCache, infer_meta, infer_meta_for_layer
 from ...proxy_tensor import ProxyTensor, ProxyTensorContext
 from ...symbolic.statement_ir import Symbol
 from ...symbolic.symbolic_context import SymbolicTraceContext
-from ...utils import is_paddle_api, log
+from ...utils import is_paddle_api, log, show_trackers
 from .pycode_generator import PyCodeGen
 from .tracker import DummyTracker
 from .variables import (
@@ -142,10 +142,11 @@ class FunctionGraph:
         # deal side effect
         # TODO(xiongkun): add side effect handle
 
-        if True:
+        tracker_output_path = show_trackers()
+        if tracker_output_path:
             from .tracker_viewer import view_tracker
 
-            view_tracker(list(ret_vars))
+            view_tracker(list(ret_vars), tracker_output_path, format="png")
 
     def call_paddle_api(
         self,

--- a/symbolic_trace/opcode_translator/executor/function_graph.py
+++ b/symbolic_trace/opcode_translator/executor/function_graph.py
@@ -142,6 +142,11 @@ class FunctionGraph:
         # deal side effect
         # TODO(xiongkun): add side effect handle
 
+        if True:
+            from .tracker_viewer import view_tracker
+
+            view_tracker(list(ret_vars))
+
     def call_paddle_api(
         self,
         func: Callable[..., Any],

--- a/symbolic_trace/opcode_translator/executor/opcode_inline_executor.py
+++ b/symbolic_trace/opcode_translator/executor/opcode_inline_executor.py
@@ -30,6 +30,9 @@ class FunctionGlobalTracker(Tracker):
             frame
         ).__globals__[self.name]
 
+    def __repr__(self) -> str:
+        return f"FunctionGlobalTracker(fn={self.fn}, name={self.name})"
+
 
 class OpcodeInlineExecutor(OpcodeExecutorBase):
     def __init__(self, fn_variable, *args, **kwargs):

--- a/symbolic_trace/opcode_translator/executor/tracker.py
+++ b/symbolic_trace/opcode_translator/executor/tracker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import builtins
 from typing import TYPE_CHECKING
 
-from ...utils import InnerError
+from ...utils import InnerError, NameGenerator
 
 if TYPE_CHECKING:
     from .pycode_generator import PyCodeGen
@@ -16,9 +16,11 @@ def from_instruction(instr):
 
 class Tracker:
     inputs: list[VariableBase]
+    name_generator = NameGenerator("tracker_")
 
     def __init__(self, inputs: list[VariableBase]):
         self.inputs = inputs
+        self.id = Tracker.name_generator.next()
 
     def gen_instructions(self, codegen: PyCodeGen):
         raise NotImplementedError()

--- a/symbolic_trace/opcode_translator/executor/tracker.py
+++ b/symbolic_trace/opcode_translator/executor/tracker.py
@@ -45,6 +45,9 @@ class DummyTracker(Tracker):
     def trace_value_from_frame(self):
         raise InnerError("DummyTracker can't trace value from frame")
 
+    def __repr__(self) -> str:
+        return f"DummyTracker(num_inputs={len(self.inputs)})"
+
 
 class LocalTracker(Tracker):
     def __init__(self, name: str):
@@ -56,6 +59,9 @@ class LocalTracker(Tracker):
 
     def trace_value_from_frame(self):
         return lambda frame: frame.f_locals[self.name]
+
+    def __repr__(self) -> str:
+        return f"LocalTracker(name={self.name})"
 
 
 class GlobalTracker(Tracker):
@@ -69,6 +75,9 @@ class GlobalTracker(Tracker):
     def trace_value_from_frame(self):
         return lambda frame: frame.f_globals[self.name]
 
+    def __repr__(self) -> str:
+        return f"GlobalTracker(name={self.name})"
+
 
 class BuiltinTracker(Tracker):
     def __init__(self, name: str):
@@ -81,6 +90,9 @@ class BuiltinTracker(Tracker):
     def trace_value_from_frame(self):
         return lambda frame: builtins.__dict__[self.name]
 
+    def __repr__(self) -> str:
+        return f"BuiltinTracker(name={self.name})"
+
 
 class ConstTracker(Tracker):
     def __init__(self, value):
@@ -92,6 +104,9 @@ class ConstTracker(Tracker):
 
     def trace_value_from_frame(self):
         return lambda frame: self.value
+
+    def __repr__(self) -> str:
+        return f"ConstTracker(value={self.value})"
 
 
 class GetAttrTracker(Tracker):
@@ -108,6 +123,9 @@ class GetAttrTracker(Tracker):
         return lambda frame: getattr(
             self.obj.tracker.trace_value_from_frame()(frame), self.attr
         )
+
+    def __repr__(self) -> str:
+        return f"GetAttrTracker(attr={self.attr})"
 
 
 class GetItemTracker(Tracker):
@@ -127,3 +145,6 @@ class GetItemTracker(Tracker):
             return container[self.key]
 
         return trace_value
+
+    def __repr__(self) -> str:
+        return f"GetItemTracker(key={self.key})"

--- a/symbolic_trace/opcode_translator/executor/tracker_viewer.py
+++ b/symbolic_trace/opcode_translator/executor/tracker_viewer.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import queue
+from typing import TYPE_CHECKING
+
+from .variables import VariableBase
+
+if TYPE_CHECKING:
+    import graphviz
+
+
+def try_import_graphviz():
+    try:
+        import graphviz
+
+        return graphviz
+    except ImportError:
+        return None
+
+
+def draw_variable(graph: graphviz.Digraph, var: VariableBase):
+    # Draw Variable
+    graph.attr('node', shape='oval')
+    graph.node(var.id, str(var))
+
+    # Draw Tracker
+    tracker = var.tracker
+    tracker_name = tracker.__class__.__name__
+    graph.attr('node', shape='rect')
+    graph.node(tracker.id, tracker_name)
+    # graph.node(str(tracker_id))
+
+    # Draw edge (Tracker -> Variable)
+    graph.edge(tracker.id, var.id)
+
+    # Draw edge (Tracker inputs -> Tracker)
+    for input in tracker.inputs:
+        graph.edge(input.id, tracker.id)
+
+
+def view_tracker(root_variables: list[VariableBase]):
+    graphviz = try_import_graphviz()
+    if graphviz is None:
+        print("Cannot import graphviz, please install it first.")
+        return
+
+    graph = graphviz.Digraph("graph", filename="out", format="png")
+    visited = set()
+    var_queue = queue.Queue()
+    for var in root_variables:
+        var_queue.put(var)
+
+    while not var_queue.empty():
+        var = var_queue.get()
+        if var.id in visited:
+            continue
+        visited.add(var.id)
+        draw_variable(graph, var)
+        for input in var.tracker.inputs:
+            if input not in var_queue.queue:
+                var_queue.put(input)
+
+    graph.render(view=False)

--- a/symbolic_trace/opcode_translator/executor/tracker_viewer.py
+++ b/symbolic_trace/opcode_translator/executor/tracker_viewer.py
@@ -32,9 +32,8 @@ def draw_variable(graph: graphviz.Digraph, var: VariableBase):
     if isinstance(tracker, DummyTracker):
         graph.attr('edge', style='dashed')
         graph.attr('node', style='dashed')
-    tracker_name = tracker.__class__.__name__
     graph.attr('node', shape='rect')
-    graph.node(tracker.id, tracker_name)
+    graph.node(tracker.id, str(tracker))
 
     # Draw edge (Tracker -> Variable)
     graph.edge(tracker.id, var.id)

--- a/symbolic_trace/opcode_translator/executor/variables.py
+++ b/symbolic_trace/opcode_translator/executor/variables.py
@@ -105,7 +105,7 @@ class VariableBase:
     """
 
     tracker: Tracker
-    name_generator = NameGenerator("tracker_")
+    name_generator = NameGenerator("object_")
 
     def __init__(self, tracker: Tracker):
         self.tracker = tracker

--- a/symbolic_trace/opcode_translator/skip_files.py
+++ b/symbolic_trace/opcode_translator/skip_files.py
@@ -19,6 +19,8 @@ import random
 import re
 import selectors
 import signal
+import sre_compile
+import sre_parse
 import sys
 import tempfile
 import threading
@@ -67,6 +69,8 @@ skip_file_names = {
         random,
         re,
         selectors,
+        sre_compile,
+        sre_parse,
         signal,
         tempfile,
         threading,

--- a/symbolic_trace/symbolic/statement_ir.py
+++ b/symbolic_trace/symbolic/statement_ir.py
@@ -177,7 +177,9 @@ class StatementIRFactory:
 
     def clear(self):
         want_clear = [
-            key for key in self.cache.keys() if key.startswith("SIR_")
+            key
+            for key in self.cache.keys()
+            if self.name_generator.match_name(key)
         ]
         for key in want_clear:
             del self.cache[key]

--- a/symbolic_trace/utils/__init__.py
+++ b/symbolic_trace/utils/__init__.py
@@ -21,6 +21,7 @@ from .utils import (
     meta_str,
     no_eval_frame,
     paddle_tensor_method,
+    show_trackers,
 )
 
 __all__ = [
@@ -47,4 +48,5 @@ __all__ = [
     "ResumeFnNameFactory",
     "list_contain_by_id",
     "list_find_index_by_id",
+    "show_trackers",
 ]

--- a/symbolic_trace/utils/utils.py
+++ b/symbolic_trace/utils/utils.py
@@ -42,6 +42,9 @@ class NameGenerator:
         self.counter += 1
         return name
 
+    def match_name(self, name: str) -> bool:
+        return name.startswith(self.prefix)
+
 
 @Singleton
 class ResumeFnNameFactory:

--- a/symbolic_trace/utils/utils.py
+++ b/symbolic_trace/utils/utils.py
@@ -200,6 +200,10 @@ def is_strict_mode():
     return os.environ.get("STRICT_MODE", "0") == "1"
 
 
+def show_trackers() -> str | None:
+    return os.environ.get("SHOW_TRACKERS", None)
+
+
 def ASSERT(input: bool):
     assert input
 


### PR DESCRIPTION
可使用环境变量 `SHOW_TRACKERS` 来控制输出的路径

![out](https://github.com/2742195759/paddle-symbolic-trace/assets/38436475/f32ff79e-e09f-447b-bdce-2043d11a3cea)

绿框中的是 SIR 组网部分（目前判断是否是组网部分没有太好的方式，只是通过判断结点是 TensorVariable 且 tracker 是 DummyTracker 来间接判断的，也许之后我们可以将 DummyTracker 替换成 SIRTracker 来表示该部分已经在组网内了，不过目前还不清楚必要性）

graphviz 不会作为必选依赖自动安装，需要自行手动安装，包含 PyPI 包和 dot 工具可执行文件两部分

详情见 https://github.com/xflr6/graphviz#installation ，后者如果使用 Homebrew 的话可以直接 `brew install graphviz` 来安装

## References

- [graphviz (python package) docs](https://graphviz.readthedocs.io/en/stable/manual.html)
- [graphviz (python pacakge) GitHub](https://github.com/xflr6/graphviz)
- [graphviz docs](https://graphviz.org/)