### PR TITLE
`__getattr__` -> `getattr`

### DIFF
--- a/symbolic_trace/opcode_translator/executor/opcode_executor.py
+++ b/symbolic_trace/opcode_translator/executor/opcode_executor.py
@@ -281,7 +281,7 @@ class OpcodeExecutorBase:
     def LOAD_ATTR(self, instr):
         attr_name = instr.argval
         obj = self.pop()
-        self.push(getattr(obj, attr_name))
+        self.push(obj.getattr(attr_name))
 
     def LOAD_FAST(self, instr):
         varname = instr.argval
@@ -291,7 +291,7 @@ class OpcodeExecutorBase:
     def LOAD_METHOD(self, instr):
         method_name = instr.argval
         obj = self.pop()
-        method = getattr(obj, method_name)
+        method = obj.getattr(method_name)
         self.push(method)
 
     def STORE_FAST(self, instr):

--- a/symbolic_trace/opcode_translator/executor/opcode_executor.py
+++ b/symbolic_trace/opcode_translator/executor/opcode_executor.py
@@ -605,7 +605,7 @@ class OpcodeExecutorBase:
         for s in str_list:
             assert isinstance(s.value, str)
             new_str += s.value
-        self.push(ConstantVariable.wrap_literal(new_str))
+        self.push(ConstantVariable.wrap_literal(new_str, self._graph))
 
     def FORMAT_VALUE(self, instr):
 
@@ -761,7 +761,7 @@ class OpcodeExecutorBase:
 
         self.push(
             UserDefinedFunctionVariable(
-                new_fn, self._graph, DummyTracker(related_list)
+                new_fn, graph=self._graph, tracker=DummyTracker(related_list)
             )
         )
 


### PR DESCRIPTION
一个简单的重构

- 将 `__getattr__` 替换成 `getattr`，以避免访问属性时出现的很多意外的行为
- 将 graph 字段放到基类上