### PR TITLE
fix the incorrectly cleaned sir cache

### DIFF
--- a/symbolic_trace/opcode_translator/executor/variables.py
+++ b/symbolic_trace/opcode_translator/executor/variables.py
@@ -345,7 +345,13 @@ class TensorVariable(VariableBase):
         return f"TensorVariable{self.meta}"
 
     def __getitem__(self, key):
-        return self.graph.call_tensor_method('__getitem__', self, key)
+        return self.graph.call_tensor_method(
+            '__getitem__',
+            self,
+            VariableFactory.from_value(
+                key, self.graph, tracker=ConstTracker(key)
+            ),
+        )
 
     @property
     def T(self):

--- a/symbolic_trace/opcode_translator/skip_files.py
+++ b/symbolic_trace/opcode_translator/skip_files.py
@@ -35,6 +35,7 @@ import weakref
 import _collections_abc
 import _weakrefset
 import decorator
+import google.protobuf
 import numpy
 
 
@@ -57,6 +58,7 @@ skip_file_names = {
         dataclasses,
         enum,
         functools,
+        google.protobuf,
         importlib,
         inspect,
         linecache,

--- a/symbolic_trace/symbolic/symbolic_context.py
+++ b/symbolic_trace/symbolic/symbolic_context.py
@@ -11,7 +11,6 @@ class SymbolicTraceContext:
 
     def reset(self):
         self.statement_factory = StatementIRFactory()
-        self.statement_factory.clear()
         self.sir_stack = [self.statement_factory.create()]
 
     @property


### PR DESCRIPTION
修复若干小问题：

- 非单例的 SymbolicTraceContext 在初始化时清理了单例的 StatementIRFactory，导致之后 cache 命中时找不到之前的 SIR
- call_tensor_method 的 key 未传入 Variable
- skip 掉 google.protobuf

单测 45/120 success