### PR TITLE
exclude non-operator-related API

### DIFF
--- a/symbolic_trace/utils/paddle_api_config.py
+++ b/symbolic_trace/utils/paddle_api_config.py
@@ -19,13 +19,30 @@ def get_paddle_api():
         paddle.signal,
         paddle.fft,
     ]
+    non_operator_related_apis = [
+        paddle.in_dynamic_mode,
+        paddle.save,
+        paddle.load,
+        paddle.get_cuda_rng_state,
+        paddle.set_rng_state,
+        paddle.set_cuda_rng_state,
+        paddle.get_rng_state,
+        paddle.set_default_dtype,
+        paddle.check_shape,
+        paddle.summary,
+        paddle.finfo,
+        paddle.iinfo,
+        paddle.enable_static,
+        paddle.disable_static,
+        paddle.is_grad_enabled,
+    ]
     paddle_api_list = []
     for module in modules:
         for fn_name in getattr(module, "__all__", []):
             fn = getattr(module, fn_name)
             if inspect.isfunction(fn):
                 paddle_api_list.append(fn)
-    return list(set(paddle_api_list))
+    return list(set(paddle_api_list) - set(non_operator_related_apis))
 
 
 paddle_tensor_methods = get_tensor_methods()


### PR DESCRIPTION
排除部分 paddle 下面的非组网 API，以解决最新版 nightly build 报错的问题

原因是最新版 `paddle.in_dynamic_mode == paddle.fluid.in_dygraph_mode`（见 PaddlePaddle/Paddle#53856），而现有逻辑会将 `paddle.in_dynamic_mode` 视为组网 API，而我们的 `__call__` 里使用了 `paddle.fluid.in_dygraph_mode`，所以最新版会报错～

#105 test_17_paddle_layer.py、test_resnet.py、test_resnet_backward.py 的报错也与此相关

单测 49/120 success