### PR TITLE
Fix stack arg name error

### DIFF
--- a/symbolic_trace/opcode_translator/executor/pycode_generator.py
+++ b/symbolic_trace/opcode_translator/executor/pycode_generator.py
@@ -234,9 +234,11 @@ class PyCodeGen:
         if self._instructions[index].opname == 'RETURN_VALUE':
             return None, set()
         inputs = analysis_inputs(self._instructions, index)
+        fn_name = ResumeFnNameFactory().next()
+        stack_arg_str = fn_name + '_stack_{}'
         self._instructions = (
             [
-                gen_instr('LOAD_FAST', argval=f'__stack_arg{i}')
+                gen_instr('LOAD_FAST', argval=stack_arg_str.format(i))
                 for i in range(stack_size)
             ]
             + [gen_instr('JUMP_ABSOLUTE', jump_to=self._instructions[index])]
@@ -246,7 +248,7 @@ class PyCodeGen:
         self._code_options['co_argcount'] = len(inputs) + stack_size
         # inputs should be at the front of the co_varnames
         self._code_options['co_varnames'] = tuple(
-            [f'__stack_arg{i}' for i in range(stack_size)]
+            [stack_arg_str.format(i) for i in range(stack_size)]
             + list(inputs)
             + [
                 var_name
@@ -254,7 +256,6 @@ class PyCodeGen:
                 if var_name not in inputs
             ]
         )
-        fn_name = ResumeFnNameFactory().next()
         self._code_options['co_name'] = fn_name
 
         new_code = self.gen_pycode()

--- a/tests/test_break_graph.py
+++ b/tests/test_break_graph.py
@@ -65,5 +65,17 @@ class TestToTensor(TestCaseBase):
         self.assert_results(to_tensor_break_graph, x, y)
 
 
+def tensor_numpy(x):
+    x = paddle.to_tensor(x)
+    x.clear_gradient()
+    return x
+
+
+class TestBreakGraphInResumeFn(TestCaseBase):
+    def test_simple(self):
+        x = paddle.to_tensor(2)
+        self.assert_results(tensor_numpy, x)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
在resume fn中再次触发break graph时会存在stack arg名字重复的问题，在这个PR中将resume fn的name作为前缀加入到stack arg name中，避免名字重复的问题