### PR TITLE
Fix unpack order error

### DIFF
--- a/symbolic_trace/opcode_translator/executor/opcode_executor.py
+++ b/symbolic_trace/opcode_translator/executor/opcode_executor.py
@@ -1105,14 +1105,12 @@ class OpcodeExecutor(OpcodeExecutorBase):
         stack_effect = dis.stack_effect(instr.opcode, instr.arg)
         self.pop_n(push_n - stack_effect)
         stack_size = len(self._stack) + push_n
-        self._graph.pycode_gen.gen_build_tuple(stack_size)
         resume_fn, _ = self._create_resume_fn(index + 1, stack_size)
         if resume_fn:
             self._graph.pycode_gen.gen_load_object(
                 resume_fn, resume_fn.__code__.co_name
             )
-            self._graph.pycode_gen._add_instr('ROT_TWO')
-            self._graph.pycode_gen.gen_unpack_sequence(stack_size)
+            self._graph.pycode_gen.gen_rot_n(stack_size + 1)
             for name in resume_input_name:
                 self._locals[name].reconstruct(self._graph.pycode_gen)
             self._graph.pycode_gen.gen_call_function(

--- a/symbolic_trace/opcode_translator/executor/pycode_generator.py
+++ b/symbolic_trace/opcode_translator/executor/pycode_generator.py
@@ -437,7 +437,7 @@ class PyCodeGen:
         else:
 
             def rot_n_fn(n):
-                vars = [f"v{i}" for i in range(n)]
+                vars = [f"var{i}" for i in range(n)]
                 rotated = reversed(vars[-1:] + vars[:-1])
                 fn = eval(f"lambda {','.join(vars)}: ({','.join(rotated)})")
                 fn.__name__ = f"rot_{n}_fn"

--- a/symbolic_trace/opcode_translator/executor/pycode_generator.py
+++ b/symbolic_trace/opcode_translator/executor/pycode_generator.py
@@ -15,6 +15,7 @@ from ...utils import (
     ResumeFnNameFactory,
     list_contain_by_id,
     list_find_index_by_id,
+    no_eval_frame,
 )
 from ..instruction_utils import (
     analysis_inputs,
@@ -440,6 +441,7 @@ class PyCodeGen:
                 vars = [f"var{i}" for i in range(n)]
                 rotated = reversed(vars[-1:] + vars[:-1])
                 fn = eval(f"lambda {','.join(vars)}: ({','.join(rotated)})")
+                fn = no_eval_frame(fn)
                 fn.__name__ = f"rot_{n}_fn"
                 return fn
 

--- a/symbolic_trace/opcode_translator/executor/pycode_generator.py
+++ b/symbolic_trace/opcode_translator/executor/pycode_generator.py
@@ -429,6 +429,26 @@ class PyCodeGen:
     def gen_pop_top(self):
         self._add_instr("POP_TOP")
 
+    def gen_rot_n(self, n):
+        if n <= 1:
+            return
+        if n <= 4:
+            self._add_instr("ROT_" + ["TWO", "THREE", "FOUR"][n - 2])
+        else:
+
+            def rot_n_fn(n):
+                vars = [f"v{i}" for i in range(n)]
+                rotated = reversed(vars[-1:] + vars[:-1])
+                fn = eval(f"lambda {','.join(vars)}: ({','.join(rotated)})")
+                fn.__name__ = f"rot_{n}_fn"
+                return fn
+
+            self.gen_build_tuple(n)
+            self.gen_load_const(rot_n_fn(n))
+            self.gen_rot_n(2)
+            self._add_instr("CALL_FUNCTION_EX", arg=0)
+            self.gen_unpack_sequence(n)
+
     def gen_return(self):
         self._add_instr("RETURN_VALUE")
 

--- a/tests/test_break_graph.py
+++ b/tests/test_break_graph.py
@@ -78,7 +78,7 @@ class TestBreakGraphInResumeFn(TestCaseBase):
 
 
 def inner_fn(a, b, c, d):
-    return a + b + c + d
+    return a + b * c - d
 
 
 def multi_stack_args(a, b, c):

--- a/tests/test_break_graph.py
+++ b/tests/test_break_graph.py
@@ -77,5 +77,22 @@ class TestBreakGraphInResumeFn(TestCaseBase):
         self.assert_results(tensor_numpy, x)
 
 
+def inner_fn(a, b, c, d):
+    return a + b + c + d
+
+
+def multi_stack_args(a, b, c):
+    out = inner_fn(a, b, c, paddle.to_tensor(4))
+    return out
+
+
+class TestMultiStackArgs(TestCaseBase):
+    def test_simple(self):
+        a = paddle.to_tensor(1)
+        b = paddle.to_tensor(2)
+        c = paddle.to_tensor(3)
+        self.assert_results(multi_stack_args, a, b, c)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
之前抽取函数时对于栈上的元素，会通过BUILD_TUPLE、UNPACK_SEQUENCE和ROT_TWO字节码调整函数和参数的位置，但是因为UNPACK_SEQUENCE字节码之后push元素的顺序是从右到左，导致函数传参的顺序错误
现在添加了rot_n的方式来调整函数和参数的顺序，如果n<=4，会直接构造ROT_TOW、ROT_THREE、ROT_FOUR字节码，但是如果n>=5会通过一个子函数调用来进行rot_n的操作（似乎只会有python3.10才有ROT_N这个字节码）

以multi_stack_args这个函数为例
```
def inner_fn(a, b, c, d):
    return a + b * c - d


def multi_stack_args(a, b, c):
    out = inner_fn(a, b, c, paddle.to_tensor(4))
    return out
```

multi_stack_args原始字节码：
```
 85           0 LOAD_GLOBAL              0 (inner_fn)
              2 LOAD_FAST                0 (a)
              4 LOAD_FAST                1 (b)
              6 LOAD_FAST                2 (c)
              8 LOAD_GLOBAL              1 (paddle)
             10 LOAD_METHOD              2 (to_tensor)
             12 LOAD_CONST               1 (4)
             14 CALL_METHOD              1
             16 CALL_FUNCTION            4
             18 STORE_FAST               3 (out)

 86          20 LOAD_FAST                3 (out)
             22 RETURN_VALUE
```

multi_stack_args转写后字节码如下
```
 84           0 LOAD_GLOBAL              3 (dummy_func)
              2 BUILD_TUPLE              0
              4 CALL_FUNCTION            1
              6 UNPACK_SEQUENCE          0
              8 LOAD_FAST                0 (a)
             10 LOAD_FAST                1 (b)
             12 LOAD_FAST                2 (c)
             14 POP_TOP
             16 POP_TOP
             18 POP_TOP
             20 LOAD_GLOBAL              0 (inner_fn)
             22 LOAD_FAST                0 (a)
             24 LOAD_FAST                1 (b)
             26 LOAD_FAST                2 (c)
             28 LOAD_CONST               2 (0)
             30 LOAD_CONST               0 (None)
             32 IMPORT_NAME              4 (sys)
             34 STORE_FAST               4 (sys)
             36 LOAD_FAST                4 (sys)
             38 LOAD_METHOD              5 (getsizeof)
             40 POP_TOP
             42 LOAD_GLOBAL              1 (paddle)
             44 LOAD_ATTR                2 (to_tensor)
             46 LOAD_CONST               1 (4)
             48 CALL_METHOD              1
             50 LOAD_GLOBAL              6 (__resume_fn_0)
             52 BUILD_TUPLE              6
             54 LOAD_CONST               3 (<function <lambda> at 0x7f856901f160>)
             56 ROT_TWO
             58 CALL_FUNCTION_EX         0
             60 UNPACK_SEQUENCE          6
             62 CALL_FUNCTION            5
             64 RETURN_VALUE
```

