### PR TITLE
add type checker for  stack push(pop)

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -326,6 +326,9 @@ class OpcodeExecutorBase:
         return retval
 
     def push(self, val: VariableBase):
+        assert isinstance(
+            val, VariableBase
+        ), f"value: {val}, type shoule be VariableBase(or derived), but get {type(val)}"
         self._stack.append(val)
 
     def DUP_TOP(self, instr):


### PR DESCRIPTION
[first issue😘]
解决方案：
1. 在所有入栈指令处进行检查
2. 在最底层`self.push`检查，和对`stack`进行`inplace`操作的地方检查。
经检查，目前`inplace`操作只有**两处**，且保证了是`Variable`，因此选择方法2。