### PR TITLE
optimize `analysis_inputs`

### DIFF
--- a/sot/opcode_translator/instruction_utils/opcode_analysis.py
+++ b/sot/opcode_translator/instruction_utils/opcode_analysis.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import dataclasses
+import sys
 
 from .instruction_utils import Instruction
 from .opcode_info import ALL_JUMP, HAS_FREE, HAS_LOCAL
+
+sys.path.append("/home/pfcc/PaddleSOT/")
 
 
 @dataclasses.dataclass
@@ -32,7 +35,7 @@ def analysis_inputs(
             if instr.opname in HAS_LOCAL | HAS_FREE:
                 if (
                     instr.opname.startswith("LOAD")
-                    and instr.argval not in must.writes
+                    and instr.argval not in state.writes
                 ):
                     state.reads.add(instr.argval)
                 elif instr.opname.startswith("STORE"):

--- a/sot/opcode_translator/instruction_utils/opcode_analysis.py
+++ b/sot/opcode_translator/instruction_utils/opcode_analysis.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import dataclasses
-import sys
 
 from .instruction_utils import Instruction
 from .opcode_info import ALL_JUMP, HAS_FREE, HAS_LOCAL
-
-sys.path.append("/home/pfcc/PaddleSOT/")
 
 
 @dataclasses.dataclass

--- a/sot/opcode_translator/instruction_utils/opcode_analysis.py
+++ b/sot/opcode_translator/instruction_utils/opcode_analysis.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
+import dataclasses
+
 from .instruction_utils import Instruction
 from .opcode_info import ALL_JUMP, HAS_FREE, HAS_LOCAL
+
+
+@dataclasses.dataclass
+class ReadsWrites:
+    reads: set
+    writes: set
+    visited: set
 
 
 def analysis_inputs(
@@ -9,31 +18,30 @@ def analysis_inputs(
     current_instr_idx: int,
     stop_instr_idx: int | None = None,
 ):
-    writes = set()
-    reads = set()
-    visited = set()
+    must = ReadsWrites(set(), set(), set())
+    may = ReadsWrites(set(), set(), set())
 
-    def walk(start):
+    def walk(state, start):
         end = len(instructions) if stop_instr_idx is None else stop_instr_idx
         for i in range(start, end):
-            if i in visited:
+            if i in state.visited:
                 continue
-            visited.add(i)
+            state.visited.add(i)
 
             instr = instructions[i]
             if instr.opname in HAS_LOCAL | HAS_FREE:
                 if (
                     instr.opname.startswith("LOAD")
-                    and instr.argval not in writes
+                    and instr.argval not in must.writes
                 ):
-                    reads.add(instr.argval)
+                    state.reads.add(instr.argval)
                 elif instr.opname.startswith("STORE"):
-                    writes.add(instr.argval)
+                    state.writes.add(instr.argval)
             elif instr.opname in ALL_JUMP:
                 assert instr.jump_to is not None
                 target_idx = instructions.index(instr.jump_to)
                 # Fork to two branches, jump or not
-                walk(target_idx)
+                walk(may, target_idx)
 
-    walk(current_instr_idx)
-    return reads
+    walk(must, current_instr_idx)
+    return must.reads | may.reads

--- a/tests/test_analysis_inputs.py
+++ b/tests/test_analysis_inputs.py
@@ -122,8 +122,8 @@ class TestAnalysisInputs(unittest.TestCase):
     def test_case6(self):
         case6(paddle.to_tensor([6]))
 
-    # def test_case7(self):
-    #     case7(paddle.to_tensor([7]))
+    def test_case7(self):
+        case7(paddle.to_tensor([7]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
分析#125 中的问题;
case7的问题是由于在分析else分支时a被存入writes集合中，之后分析另一分支时就不会被存入reads集合中。
解决方式：
参考torch,对不同分支用不同的集合。
https://github.com/pytorch/pytorch/blob/fe05266fda4f908130dea7cbac37e9264c0429a2/torch/_dynamo/bytecode_analysis.py#L96
但无法通过case3, case4。
![image](https://github.com/PaddlePaddle/PaddleSOT/assets/10421743/b5c95eef-eae4-4d13-b40f-c1d00a915957)
opcode_analysis看起来应该是分析当前字节码之后被用到的局部变量，case3,case4的结果好像不符合这个逻辑？

closes #125