### PR TITLE
Add not equal ut

### DIFF
--- a/tests/test_14_operators.py
+++ b/tests/test_14_operators.py
@@ -199,5 +199,19 @@ class TestExecutor(TestCaseBase):
         self.assert_results(inplace_xor, b, g)
 
 
+def run_not_eq(x: paddle.Tensor, y: int):
+    out = paddle.reshape(x, [1, -1]) != y
+    out = out.astype('float32')
+    return out
+
+
+class TestNotEq(TestCaseBase):
+    # TODO(SigureMo): Open this case after support builtin dispatch
+    def close_test_not_eq(self):
+        x = paddle.to_tensor([2])
+        y = 3
+        self.assert_results(run_not_eq, x, y)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
新增了一个operator的单测，对于单测中的`tensot != int`这样的语句需要加入到组网中，但是目前的代码无法将类似的代码加入到组网中，晓健支持builtin的分发之后可以支持这种case