### PR TITLE
refine project information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 __pycache__
 *.sw*
 user_tag
-build/
-sot.egg-info/
 
 # Editor config
 .vscode
@@ -10,3 +8,7 @@ sot.egg-info/
 # Environments
 venv/
 .venv/
+
+# Build
+build/
+*.egg-info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,17 @@ deactivate                                      # 退出环境
 
 你可以在激活环境后运行 `python --version` 确保 Python 版本正确。
 
-### 安装依赖
+### 安装
 
 目前 Paddle SOT 主体部分是独立于 Paddle 开发的，因此开发过程中不需要和 Paddle 一起编译，你只需要安装 Paddle 的 wheel 包即可。
 
 但由于我们有部分特性（Eval Frame 相关部分）是放在 Paddle C++ 端编译的，所以需要依赖于最新的 Paddle wheel 包（即 nightly build），你可以在[官网安装页面](https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/develop/install/pip/linux-pip.html)根据自己的平台找到相应的安装方式
+
+之后只需要通过如下命令即可安装 PaddleSOT：
+
+```bash
+pip install -e .
+```
 
 ### 运行单测
 
@@ -77,7 +83,7 @@ pre-commit run --all-files
 你可以通过如下方式来运行示例代码：
 
 ```bash
-LOG_LEVEL=3 PYTHONPATH=. python examples/trace_basic.py
+LOG_LEVEL=3 python examples/trace_basic.py
 ```
 
 运行如上示例，你可以看到如下的 log：
@@ -147,7 +153,7 @@ I0601 15:07:44.390908 4192656896 interpretercore.cc:237] New Executor is Running
 这里主要展示 DDCF 的情况：
 
 ```bash
-LOG_LEVEL=3 PYTHONPATH=. python examples/graph_break.py
+LOG_LEVEL=3 python examples/graph_break.py
 ```
 
 `foo` 函数的字节码如下：
@@ -280,7 +286,7 @@ LOG_LEVEL=3 PYTHONPATH=. python examples/graph_break.py
 ```bash
 # 通过环境变量 SHOW_TRACKERS 你可以看到 Python 端所有 Variable 依赖关系
 # 不过在此之前你需要先按照 https://github.com/PaddlePaddle/PaddleSOT/pull/82 说明安装好 graphviz 库和 dot 可执行文件
-SHOW_TRACKERS=out LOG_LEVEL=3 PYTHONPATH=. python examples/guard.py
+SHOW_TRACKERS=out LOG_LEVEL=3 python examples/guard.py
 ```
 
 在 log 中，我们可以看到第二次和第三次执行分别发生了 `cache hit` 和 `cache miss`，这是因为我们在第一次执行生成字节码的同时，还生成了相应的 Guard，我们可以在 log 中找到 Guard 代码：

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,203 @@
+Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ cd PaddleSOT/
 pip install -e .
 ```
 
+此外由于我们有部分特性依赖于最新的 PaddlePaddle，因此你需要安装 Nightly build 版本的 PaddlePaddle，你可以在[官网安装页面](https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/develop/install/pip/linux-pip.html)根据自己的平台找到相应的安装方式
+
 ## Usage
 
 你可以通过运行 `examples/` 下的示例来了解 PaddleSOT 的使用方法。

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Paddle** **S**ymbolic **O**pcode **T**ranslator.
 
-PaddleSOT 是一个基于字节码的 JIT 编译器，可以在运行时将 PaddlePaddle 动态图组网代码转换为静态图组网代码，是飞桨动转静体系下的子图 Fallback 孵化项目。
+PaddleSOT 是一个 Opcode-Based 的动转静孵化项目，借助 Symbolic Opcode Translator（简称：SOT）在运行时将 PaddlePaddle 动态图组网代码转换为静态图组网代码，具体设计参见：[PaddleSOT 项目介绍](https://github.com/PaddlePaddle/community/tree/master/pfcc/paddle-code-reading/symbolic_opcode_translator)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # PaddleSOT
 
-<!-- TODO: user guide -->
+**Paddle** **S**ymbolic **O**pcode **T**ranslator.
+
+PaddleSOT 是一个基于字节码的 JIT 编译器，可以在运行时将 PaddlePaddle 动态图组网代码转换为静态图组网代码，是飞桨动转静体系下的子图 Fallback 孵化项目。
+
+## Install
+
+```bash
+git clone https://github.com/PaddlePaddle/PaddleSOT.git
+cd PaddleSOT/
+pip install -e .
+```
+
+## Usage
+
+你可以通过运行 `examples/` 下的示例来了解 PaddleSOT 的使用方法。
+
+```bash
+python examples/trace_basic.py
+```
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,31 @@
+[build-system]
+requires = ["setuptools>=61.0.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "PaddleSOT"
+version = "0.0.1a0"
+description = "A Bytecode level Implementation of Symbolic OpCode Translator For PaddlePaddle"
+readme = "README.md"
+requires-python = ">=3.8,<3.11"
+authors = [
+    {name = "PaddlePaddle", email = "Paddle-better@baidu.com"},
+]
+keywords = ["Framework", "Deep Learning", "JIT"]
+license = { file = "LICENSE" }
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Operating System :: OS Independent",
+]
+
+[tool.setuptools]
+packages = ["sot"]
+
 [tool.black]
 line-length = 80
 skip-string-normalization = true

--- a/sot/opcode_translator/executor/variables/base.py
+++ b/sot/opcode_translator/executor/variables/base.py
@@ -28,22 +28,6 @@ if TYPE_CHECKING:
 ConstTypes = (int, float, str, bool, type(None))
 
 
-DTYPE_ABBRS = {
-    paddle.bfloat16: 'bfloat16',
-    paddle.float64: 'float64',
-    paddle.float32: 'float32',
-    paddle.float16: 'float16',
-    paddle.complex64: 'complex64',
-    paddle.complex128: 'complex128',
-    paddle.int8: 'int8',
-    paddle.int16: 'int16',
-    paddle.int32: 'int32',
-    paddle.int64: 'int64',
-    paddle.bool: 'bool',
-    paddle.uint8: 'uint8',
-}
-
-
 def get_zero_degree_vars(
     variables: set[VariableBase], visited_vars: list[VariableBase]
 ) -> list[VariableBase]:
@@ -306,12 +290,7 @@ class VariableBase:
 
     def __repr__(self):
         info = {**self.main_info, **self.debug_info}
-        info_str = ", ".join(
-            [
-                f"{value}" if key != 'dtype' else f"{DTYPE_ABBRS[value]}"
-                for key, value in info.items()
-            ]
-        )
+        info_str = ", ".join([f"{value}" for value in info.values()])
         return f"{self.__class__.__name__}({info_str})"
 
     def __str__(self):

--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -33,6 +33,21 @@ from .base import ConstTypes, VariableBase, VariableFactory
 if TYPE_CHECKING:
     from ..function_graph import FunctionGraph
 
+DTYPE_ABBRS = {
+    paddle.bfloat16: 'bfloat16',
+    paddle.float64: 'float64',
+    paddle.float32: 'float32',
+    paddle.float16: 'float16',
+    paddle.complex64: 'complex64',
+    paddle.complex128: 'complex128',
+    paddle.int8: 'int8',
+    paddle.int16: 'int16',
+    paddle.int32: 'int32',
+    paddle.int64: 'int64',
+    paddle.bool: 'bool',
+    paddle.uint8: 'uint8',
+}
+
 
 class ConstantVariable(VariableBase):
     def __init__(
@@ -147,7 +162,7 @@ class TensorVariable(VariableBase):
     def main_info(self) -> dict[str, Any]:
         return {
             "shape": self.meta.shape,
-            "dtype": self.meta.dtype,
+            "dtype": DTYPE_ABBRS[self.meta.dtype],
             "stop_gradient": self.meta.stop_gradient,
             "var_name": self.var_name,
         }


### PR DESCRIPTION
完善项目信息、元数据

- 完善 README.md，增加最简的 README 信息，以挖掘通过 GitHub 直接访问到的潜在贡献者（不然看到啥也没有的 README 都不知道是个啥，直接划走了），在 https://github.com/PaddlePaddle/PaddleSOT/graphs/traffic 可以看到直接从 GitHub 访问的人还是蛮多的
- 完善 `project.toml` 元信息，见 [PEP 517](https://peps.python.org/pep-0517/) 和 [PEP 621](https://peps.python.org/pep-0621/)，允许通过 `pip install -e .` 的方式直接安装 PaddleSOT，这样就不需要在运行命令时再 `PYTHONPATH=.` 了，方便开发者的开发，而且 `-e` 代表 `editable`，即修改代码后不必重新安装，该方式兼容现有开发方式，不会对我们现有的 `PYTHONPATH=.` 开发方式造成任何影响
- 增加 LICENSE（同 Paddle）

另外调了下刚刚 merge 的 #183 的代码，dtype 没必要在 repr 处根据 key 来判断