### PR TITLE
[log] fix eval_frame_callback log err

### DIFF
--- a/sot/opcode_translator/transform.py
+++ b/sot/opcode_translator/transform.py
@@ -30,7 +30,7 @@ def eval_frame_callback(frame, **kwargs):
         if new_code is not None:
             log_do(7, lambda: dis.dis(new_code.code))
         else:
-            log_do(7, f"Skip frame: {frame.f_code.co_name}")
+            log(7, f"Skip frame: {frame.f_code.co_name}")
 
         return new_code
     return None


### PR DESCRIPTION
```bash
======================================================================
ERROR: test_closure (__main__.TestExecutor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_19_closure.py", line 165, in test_closure
    self.assert_results(
  File "/Users/gouzi/Downloads/PaddleSOT/tests/test_case_base.py", line 53, in assert_results
    sym_output = symbolic_translate(func)(*inputs)
  File "/Users/gouzi/Downloads/PaddleSOT/sot/translate.py", line 82, in impl
    raise e
  File "/Users/gouzi/Downloads/PaddleSOT/sot/translate.py", line 80, in impl
    outs = fn(*args, **kwargs)
  File "/Users/gouzi/Downloads/PaddleSOT/sot/translate.py", line 74, in callback
    return eval_frame_callback(frame, **kwargs)
  File "/Users/gouzi/Downloads/PaddleSOT/sot/opcode_translator/transform.py", line 34, in eval_frame_callback
    log_do(7, f"Skip frame: {frame.f_code.co_name}")
  File "/Users/gouzi/Downloads/PaddleSOT/sot/utils/utils.py", line 67, in log_do
    fn()
TypeError: 'str' object is not callable
```