### PR TITLE
[Dispatcher] Support more ListVariable operations

### DIFF
--- a/sot/opcode_translator/executor/variable_dispatch.py
+++ b/sot/opcode_translator/executor/variable_dispatch.py
@@ -196,6 +196,12 @@ Dispatcher.register(
     lambda var: var.copy(),
 )
 Dispatcher.register(
+    list.count,
+    ("ListVariable", "VariableBase"),
+    {},
+    lambda var, obj: var.count(obj),
+)
+Dispatcher.register(
     operator.add,
     ("ListVariable", "ListVariable"),
     {},

--- a/sot/opcode_translator/executor/variable_dispatch.py
+++ b/sot/opcode_translator/executor/variable_dispatch.py
@@ -190,6 +190,12 @@ Dispatcher.register(
     lambda var: var.reverse(),
 )
 Dispatcher.register(
+    list.copy,
+    ("ListVariable",),
+    {},
+    lambda var: var.copy(),
+)
+Dispatcher.register(
     operator.add,
     ("ListVariable", "ListVariable"),
     {},

--- a/sot/opcode_translator/executor/variable_dispatch.py
+++ b/sot/opcode_translator/executor/variable_dispatch.py
@@ -202,6 +202,12 @@ Dispatcher.register(
     lambda var, obj: var.count(obj),
 )
 Dispatcher.register(
+    list.index,
+    ("ListVariable", "VariableBase"),
+    {},
+    lambda var, obj: var.index(obj),
+)
+Dispatcher.register(
     operator.add,
     ("ListVariable", "ListVariable"),
     {},

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -289,6 +289,14 @@ class ListVariable(ContainerVariable):
         self.graph.side_effects.record_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
+    def count(self, obj: VariableBase):
+        res = 0
+        for i in self:
+            if i == obj:
+                res += 1
+
+        return ConstantVariable.wrap_literal(res, self.graph)
+
     def getattr(self, name):
         from .callable import BuiltinVariable
 
@@ -302,6 +310,7 @@ class ListVariable(ContainerVariable):
             "remove": list.remove,
             "sort": list.sort,
             "reverse": list.reverse,
+            "count": list.count,
         }
 
         if name in method_name_to_builtin_fn:
@@ -311,7 +320,7 @@ class ListVariable(ContainerVariable):
             ).bind(self, name)
         else:
             raise NotImplementException(
-                f"attribute {name} for dict is not implemented"
+                f"attribute {name} for list is not implemented"
             )
 
     @VariableFactory.register_from_value()

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -297,6 +297,15 @@ class ListVariable(ContainerVariable):
 
         return ConstantVariable.wrap_literal(res, self.graph)
 
+    def index(self, obj: VariableBase):
+        res = 0
+        for i in self:
+            if i == obj:
+                return ConstantVariable.wrap_literal(res, self.graph)
+            res += 1
+
+        return ConstantVariable.wrap_literal(-1, self.graph)
+
     def getattr(self, name):
         from .callable import BuiltinVariable
 
@@ -311,6 +320,7 @@ class ListVariable(ContainerVariable):
             "sort": list.sort,
             "reverse": list.reverse,
             "count": list.count,
+            "index": list.index,
         }
 
         if name in method_name_to_builtin_fn:

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -97,6 +97,44 @@ def list_insert(x: int, y: paddle.Tensor):
     return z
 
 
+def list_pop(x: int, y: paddle.Tensor):
+    z = [x, y]
+    a = z.pop()
+    b = z.pop()
+    return (z, a, b)
+
+
+def list_remove(x: int, y: paddle.Tensor):
+    z = [x, x, y, y]
+    z.remove(x)
+    z.remove(y)
+    return z
+
+
+def list_reverse(x: int, y: paddle.Tensor):
+    z = [x, x, y, y]
+    z.reverse()
+    return z
+
+
+def list_default_sort(x: int, y: paddle.Tensor):
+    z = [y + 2, y, y + 1]
+    z.sort()
+    return z
+
+
+def list_key_sort(x: int, y: paddle.Tensor):
+    z = [y + 2, y, y + 1]
+    z.sort(key=len)
+    return z
+
+
+def list_reverse_sort(x: int, y: paddle.Tensor):
+    z = [y + 2, y, y + 1]
+    z.sort(reverse=True)
+    return z
+
+
 class TestExecutor(TestCaseBase):
     def test_simple(self):
         self.assert_results(list_getitem_int, 1, paddle.to_tensor(2))
@@ -127,6 +165,22 @@ class TestExecutor(TestCaseBase):
         self.assert_results_with_side_effects(
             list_insert, 1, paddle.to_tensor(2)
         )
+        self.assert_results_with_side_effects(list_pop, 1, paddle.to_tensor(2))
+        self.assert_results_with_side_effects(
+            list_remove, 1, paddle.to_tensor(2)
+        )
+        self.assert_results_with_side_effects(
+            list_reverse, 1, paddle.to_tensor(2)
+        )
+        self.assert_results_with_side_effects(
+            list_reverse, 1, paddle.to_tensor(2)
+        )
+        self.assert_results_with_side_effects(
+            list_default_sort, 1, paddle.to_tensor(2)
+        )
+        # self.assert_results_with_side_effects(
+        #     list_default_sort, 1, paddle.to_tensor(2)
+        # )
 
 
 if __name__ == "__main__":

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -71,9 +71,16 @@ def list_copy(x: int, y: paddle.Tensor):
     return (a, z)
 
 
-def list_count(x: int, y: paddle.Tensor):
-    z = [x, x, y, y, y]
-    return (z.count(x), z.count(y))
+def list_count_int(x: int, y: paddle.Tensor):
+    z = [x, x, 2, 3, 1]
+    return z.count(x)
+
+
+def list_count_tensor(x: int, y: paddle.Tensor):
+    a = paddle.to_tensor(1)
+    b = paddle.to_tensor(2)
+    z = [a, b, y, y, y]
+    return z.count(y)
 
 
 def list_extend(x: int, y: paddle.Tensor):
@@ -85,9 +92,16 @@ def list_extend(x: int, y: paddle.Tensor):
     return z
 
 
-def list_index(x: int, y: paddle.Tensor):
-    z = [y, x, y, y]
-    return (z.index(x), z.index(y))
+def list_index_int(x: int, y: paddle.Tensor):
+    z = [x, x, 1, 2]
+    return z.index(x)
+
+
+def list_index_tensor(x: int, y: paddle.Tensor):
+    a = paddle.to_tensor(1)
+    b = paddle.to_tensor(2)
+    z = [a, b, y, y]
+    return z.index(y)
 
 
 def list_insert(x: int, y: paddle.Tensor):
@@ -147,8 +161,8 @@ class TestExecutor(TestCaseBase):
         self.assert_results(list_getitem_tensor, 1, paddle.to_tensor(2))
         self.assert_results(list_setitem_int, 1, paddle.to_tensor(2))
         self.assert_results(list_setitem_tensor, 1, paddle.to_tensor(2))
-        self.assert_results(list_count, 1, paddle.to_tensor(2))
-        self.assert_results(list_index, 1, paddle.to_tensor(2))
+        self.assert_results(list_count_int, 1, paddle.to_tensor(2))
+        self.assert_results(list_index_int, 1, paddle.to_tensor(2))
         self.assert_results_with_side_effects(
             list_delitem_int, 1, paddle.to_tensor(2)
         )
@@ -185,6 +199,8 @@ class TestExecutor(TestCaseBase):
             list_default_sort, 1, paddle.to_tensor(2)
         )
         # TODO: Not currently supported
+        # self.assert_results(list_count_tensor, 1, paddle.to_tensor(2))
+        # self.assert_results(list_index_tensor, 1, paddle.to_tensor(2))
         # self.assert_results_with_side_effects(
         #     list_tensor_sort, 1, paddle.to_tensor(2)
         # )

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -76,6 +76,15 @@ def list_count(x: int, y: paddle.Tensor):
     return (z.count(x), z.count(y))
 
 
+def list_extend(x: int, y: paddle.Tensor):
+    z = [x, y]
+    a = [y, x]
+    b = (x, y)
+    z.extend(a)
+    z.extend(b)
+    return z
+
+
 class TestExecutor(TestCaseBase):
     def test_simple(self):
         self.assert_results(list_getitem_int, 1, paddle.to_tensor(2))
@@ -89,6 +98,7 @@ class TestExecutor(TestCaseBase):
         self.assert_results(list_clear, 1, paddle.to_tensor(2))
         self.assert_results(list_copy, 1, paddle.to_tensor(2))
         self.assert_results(list_count, 1, paddle.to_tensor(2))
+        self.assert_results(list_extend, 1, paddle.to_tensor(2))
 
 
 if __name__ == "__main__":

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -76,11 +76,8 @@ def list_count_int(x: int, y: paddle.Tensor):
     return z.count(x)
 
 
-def list_count_tensor(x: int, y: paddle.Tensor):
-    a = paddle.to_tensor(1)
-    b = paddle.to_tensor(2)
-    z = [a, b, y, y, y]
-    return z.count(y)
+def list_count_tensor(x: paddle.Tensor, y: list[paddle.Tensor]):
+    return y.count(x)
 
 
 def list_extend(x: int, y: paddle.Tensor):
@@ -97,11 +94,8 @@ def list_index_int(x: int, y: paddle.Tensor):
     return z.index(x)
 
 
-def list_index_tensor(x: int, y: paddle.Tensor):
-    a = paddle.to_tensor(1)
-    b = paddle.to_tensor(2)
-    z = [a, b, y, y]
-    return z.index(y)
+def list_index_tensor(x: paddle.Tensor, y: list[paddle.Tensor]):
+    return y.index(x)
 
 
 def list_insert(x: int, y: paddle.Tensor):
@@ -163,6 +157,10 @@ class TestExecutor(TestCaseBase):
         self.assert_results(list_setitem_tensor, 1, paddle.to_tensor(2))
         self.assert_results(list_count_int, 1, paddle.to_tensor(2))
         self.assert_results(list_index_int, 1, paddle.to_tensor(2))
+        a = paddle.to_tensor(1)
+        b = paddle.to_tensor(2)
+        self.assert_results(list_count_tensor, a, [a, b, a, b, a, b])
+        self.assert_results(list_index_tensor, b, [a, b, a, b, a, b])
         self.assert_results_with_side_effects(
             list_delitem_int, 1, paddle.to_tensor(2)
         )
@@ -199,8 +197,6 @@ class TestExecutor(TestCaseBase):
             list_default_sort, 1, paddle.to_tensor(2)
         )
         # TODO: Not currently supported
-        # self.assert_results(list_count_tensor, 1, paddle.to_tensor(2))
-        # self.assert_results(list_index_tensor, 1, paddle.to_tensor(2))
         # self.assert_results_with_side_effects(
         #     list_tensor_sort, 1, paddle.to_tensor(2)
         # )

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -45,6 +45,32 @@ def list_delitem_tensor(x: int, y: paddle.Tensor):
     return z
 
 
+def list_append_int(x: int, y: paddle.Tensor):
+    z = [x, y]
+    z.append(3)
+    return z
+
+
+def list_append_tensor(x: int, y: paddle.Tensor):
+    z = [x, y]
+    z.append(y)
+    return z
+
+
+def list_clear(x: int, y: paddle.Tensor):
+    z = [x, y]
+    z.clear()
+    return z
+
+
+def list_copy(x: int, y: paddle.Tensor):
+    z = [x, y]
+    a = z.copy()
+    z[0] = 3
+    z[1] = y + 1
+    return (a, z)
+
+
 class TestExecutor(TestCaseBase):
     def test_simple(self):
         self.assert_results(list_getitem_int, 1, paddle.to_tensor(2))
@@ -53,6 +79,10 @@ class TestExecutor(TestCaseBase):
         self.assert_results(list_setitem_tensor, 1, paddle.to_tensor(2))
         self.assert_results(list_delitem_int, 1, paddle.to_tensor(2))
         self.assert_results(list_delitem_tensor, 1, paddle.to_tensor(2))
+        self.assert_results(list_append_int, 1, paddle.to_tensor(2))
+        self.assert_results(list_append_tensor, 1, paddle.to_tensor(2))
+        self.assert_results(list_clear, 1, paddle.to_tensor(2))
+        self.assert_results(list_copy, 1, paddle.to_tensor(2))
 
 
 if __name__ == "__main__":

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -90,21 +90,43 @@ def list_index(x: int, y: paddle.Tensor):
     return (z.index(x), z.index(y))
 
 
+def list_insert(x: int, y: paddle.Tensor):
+    z = [x, y]
+    z.insert(0, x)
+    z.insert(3, y)
+    return z
+
+
 class TestExecutor(TestCaseBase):
     def test_simple(self):
         self.assert_results(list_getitem_int, 1, paddle.to_tensor(2))
         self.assert_results(list_getitem_tensor, 1, paddle.to_tensor(2))
         self.assert_results(list_setitem_int, 1, paddle.to_tensor(2))
         self.assert_results(list_setitem_tensor, 1, paddle.to_tensor(2))
-        self.assert_results(list_delitem_int, 1, paddle.to_tensor(2))
-        self.assert_results(list_delitem_tensor, 1, paddle.to_tensor(2))
-        self.assert_results(list_append_int, 1, paddle.to_tensor(2))
-        self.assert_results(list_append_tensor, 1, paddle.to_tensor(2))
-        self.assert_results(list_clear, 1, paddle.to_tensor(2))
-        self.assert_results(list_copy, 1, paddle.to_tensor(2))
         self.assert_results(list_count, 1, paddle.to_tensor(2))
-        self.assert_results(list_extend, 1, paddle.to_tensor(2))
         self.assert_results(list_index, 1, paddle.to_tensor(2))
+        self.assert_results_with_side_effects(
+            list_delitem_int, 1, paddle.to_tensor(2)
+        )
+        self.assert_results_with_side_effects(
+            list_delitem_tensor, 1, paddle.to_tensor(2)
+        )
+        self.assert_results_with_side_effects(
+            list_append_int, 1, paddle.to_tensor(2)
+        )
+        self.assert_results_with_side_effects(
+            list_append_tensor, 1, paddle.to_tensor(2)
+        )
+        self.assert_results_with_side_effects(
+            list_clear, 1, paddle.to_tensor(2)
+        )
+        self.assert_results_with_side_effects(list_copy, 1, paddle.to_tensor(2))
+        self.assert_results_with_side_effects(
+            list_extend, 1, paddle.to_tensor(2)
+        )
+        self.assert_results_with_side_effects(
+            list_insert, 1, paddle.to_tensor(2)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -118,20 +118,26 @@ def list_reverse(x: int, y: paddle.Tensor):
 
 
 def list_default_sort(x: int, y: paddle.Tensor):
-    z = [y + 2, y, y + 1]
+    z = [x + 2, x, x + 1]
     z.sort()
     return z
 
 
 def list_key_sort(x: int, y: paddle.Tensor):
-    z = [y + 2, y, y + 1]
-    z.sort(key=len)
+    z = [x + 2, x, x + 1]
+    z.sort(lambda x: x)
     return z
 
 
 def list_reverse_sort(x: int, y: paddle.Tensor):
-    z = [y + 2, y, y + 1]
+    z = [x + 2, x, x + 1]
     z.sort(reverse=True)
+    return z
+
+
+def list_tensor_sort(x: int, y: paddle.Tensor):
+    z = [y + 2, y, y + 1]
+    z.sort()
     return z
 
 
@@ -178,8 +184,15 @@ class TestExecutor(TestCaseBase):
         self.assert_results_with_side_effects(
             list_default_sort, 1, paddle.to_tensor(2)
         )
+        # TODO: Not currently supported
         # self.assert_results_with_side_effects(
-        #     list_default_sort, 1, paddle.to_tensor(2)
+        #     list_tensor_sort, 1, paddle.to_tensor(2)
+        # )
+        # self.assert_results_with_side_effects(
+        #     list_key_sort, 1, paddle.to_tensor(2)
+        # )
+        # self.assert_results_with_side_effects(
+        #     list_reverse_sort, 1, paddle.to_tensor(2)
         # )
 
 

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -85,6 +85,11 @@ def list_extend(x: int, y: paddle.Tensor):
     return z
 
 
+def list_index(x: int, y: paddle.Tensor):
+    z = [y, x, y, y]
+    return (z.index(x), z.index(y))
+
+
 class TestExecutor(TestCaseBase):
     def test_simple(self):
         self.assert_results(list_getitem_int, 1, paddle.to_tensor(2))
@@ -99,6 +104,7 @@ class TestExecutor(TestCaseBase):
         self.assert_results(list_copy, 1, paddle.to_tensor(2))
         self.assert_results(list_count, 1, paddle.to_tensor(2))
         self.assert_results(list_extend, 1, paddle.to_tensor(2))
+        self.assert_results(list_index, 1, paddle.to_tensor(2))
 
 
 if __name__ == "__main__":

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -71,6 +71,11 @@ def list_copy(x: int, y: paddle.Tensor):
     return (a, z)
 
 
+def list_count(x: int, y: paddle.Tensor):
+    z = [x, x, y, y, y]
+    return (z.count(x), z.count(y))
+
+
 class TestExecutor(TestCaseBase):
     def test_simple(self):
         self.assert_results(list_getitem_int, 1, paddle.to_tensor(2))
@@ -83,6 +88,7 @@ class TestExecutor(TestCaseBase):
         self.assert_results(list_append_tensor, 1, paddle.to_tensor(2))
         self.assert_results(list_clear, 1, paddle.to_tensor(2))
         self.assert_results(list_copy, 1, paddle.to_tensor(2))
+        self.assert_results(list_count, 1, paddle.to_tensor(2))
 
 
 if __name__ == "__main__":

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -3,6 +3,7 @@
 # BINARY_SUBSCR
 # DELETE_SUBSCR
 
+from __future__ import annotations
 
 import unittest
 


### PR DESCRIPTION
支持更多的`ListVariable`方法

- [x] append
- [x] clear
- [x] copy
- [x] count
- [x] extend
- [x] index
- [x] insert
- [x] pop
- [x] remove
- [x] reverse
- [ ] sort 单测中列举了一些目前还不支持的操作, 后续可能考虑回滚到动态图执行


相关链接:

 * #244
