### PR TITLE
Fix the get and pop methods for DictVariable

### DIFF
--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -519,7 +519,10 @@ class DictVariable(ContainerVariable):
         if isinstance(self.proxy.get(key), MutableDictLikeData.Empty):
             if isinstance(default, VariableBase):
                 return default
-            return VariableFactory.from_value(default)
+            # In principle, it won't come here
+            return VariableFactory.from_value(
+                default, self.graph, DummyTracker([self])
+            )
 
         return self.getitem(key)
 
@@ -633,7 +636,10 @@ class DictVariable(ContainerVariable):
         if isinstance(self.proxy.get(key), MutableDictLikeData.Empty):
             if isinstance(default, VariableBase):
                 return default
-            return VariableFactory.from_value(default)
+            # In principle, it won't come here
+            return VariableFactory.from_value(
+                default, self.graph, DummyTracker([self])
+            )
 
         # default is not None, or key is in dict
         temp_value = self.getitem(key)

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -517,12 +517,8 @@ class DictVariable(ContainerVariable):
             return self.getitem(key)
 
         if isinstance(self.proxy.get(key), MutableDictLikeData.Empty):
-            if isinstance(default, VariableBase):
-                return default
-            # In principle, it won't come here
-            return VariableFactory.from_value(
-                default, self.graph, DummyTracker([self])
-            )
+            assert isinstance(default, VariableBase)
+            return default
 
         return self.getitem(key)
 
@@ -634,12 +630,8 @@ class DictVariable(ContainerVariable):
 
     def pop(self, key, default=None):
         if isinstance(self.proxy.get(key), MutableDictLikeData.Empty):
-            if isinstance(default, VariableBase):
-                return default
-            # In principle, it won't come here
-            return VariableFactory.from_value(
-                default, self.graph, DummyTracker([self])
-            )
+            assert isinstance(default, VariableBase)
+            return default
 
         # default is not None, or key is in dict
         temp_value = self.getitem(key)

--- a/tests/test_05_dict.py
+++ b/tests/test_05_dict.py
@@ -26,7 +26,7 @@ def dict_get_item(x: int, y: paddle.Tensor):
 
 def dict_get_item_default(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
-    return z.get(3, 2)
+    return (z.get(3, 2), z.get(4, y))
 
 
 def dict_set_item_int(x: int, y: paddle.Tensor):
@@ -105,7 +105,9 @@ def dict_pop(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1, 3: y}
     a = z.pop(1)
     b = z.pop(2, 3)
-    return (z, a, b)
+    c = z.pop(4, 3)
+    d = z.pop(5, y)
+    return (z, a, b, c, d)
 
 
 def dict_popitem(x: int, y: paddle.Tensor):


### PR DESCRIPTION
修复`DictVariable`的`get`和`pop`方法