### PR TITLE
add len support for TensorVariable

### DIFF
--- a/sot/opcode_translator/executor/variable_dispatch.py
+++ b/sot/opcode_translator/executor/variable_dispatch.py
@@ -516,17 +516,21 @@ fallback_tensor_unary_method = {
 Dispatcher.register(tensor_numel, ("TensorVariable",), {}, lambda x: x.numel())
 
 for unary_fn in UNARY_OPS:
-    # Tensor doesn't support unary +, skip it
-    # TODO(SigureMo): deal len and bool
-    if unary_fn in {len}:
-        continue
-
     if unary_fn in fallback_tensor_unary_method:
         Dispatcher.register(
             unary_fn,
             ("TensorVariable",),
             {},
             raise_break_graph_fn,
+        )
+        continue
+
+    if unary_fn is len:
+        Dispatcher.register(
+            unary_fn,
+            ("TensorVariable",),
+            {},
+            lambda x: x.len(),
         )
         continue
 

--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -356,6 +356,16 @@ class TensorVariable(VariableBase):
     def numel(self):
         return self.size
 
+    def len(self):
+        if len(self.shape) == 0:
+            raise InnerError("len() of a 0-D tensor is wrong")
+        first_dim = self.shape[0]
+        if first_dim == -1:
+            raise BreakGraphError(
+                "Getting len() for a dynamic shape tensor causes graph break."
+            )
+        return ConstantVariable.wrap_literal(first_dim, self.graph)
+
     def is_tensor(self):
         return ConstantVariable.wrap_literal(True, self.graph)
 

--- a/tests/test_builtin_dispatch.py
+++ b/tests/test_builtin_dispatch.py
@@ -1,13 +1,20 @@
 import operator
 import unittest
 
-from test_case_base import TestCaseBase
+from test_case_base import (
+    TestCaseBase,
+    test_instruction_translator_cache_context,
+)
 
 import paddle
 
 
 def dispatch_len(x: paddle.Tensor):
     return len(x.shape)
+
+
+def dispatch_tensor_len(x: paddle.Tensor):
+    return len(x)
 
 
 def dispatch_bool(x: paddle.Tensor):
@@ -20,6 +27,17 @@ class TestBuiltinDispatch(TestCaseBase):
 
     def test_dispatch_bool(self):
         self.assert_results(dispatch_bool, paddle.to_tensor([1, 2, 3]))
+
+    def test_dispatch_tensor_len(self):
+        with test_instruction_translator_cache_context() as ctx:
+            self.assert_results(
+                dispatch_tensor_len, paddle.to_tensor([1, 2, 3])
+            )
+            self.assertEqual(ctx.translate_count, 1)
+            self.assert_results(
+                dispatch_tensor_len, paddle.to_tensor([4, 5, 6])
+            )
+            self.assertEqual(ctx.translate_count, 1)
 
 
 def run_getattr(x: paddle.Tensor):


### PR DESCRIPTION
为 TensorVariable 支持 len，避免 `len(tensor)` 走 BuiltinVariable 第二段逻辑（从 class 上查找）