### PR TITLE
[refactor] move add global guard to VariableBase

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -795,12 +795,12 @@ class OpcodeExecutorBase:
 
     def LOAD_ATTR(self, instr: Instruction):
         attr_name = self._code.co_names[instr.arg]
-        attr_var = ConstantVariable.wrap_literal(attr_name, self._graph)
+        attr_name_var = ConstantVariable.wrap_literal(attr_name, self._graph)
         obj = self.pop()
         self.push(
             BuiltinVariable(
                 getattr, graph=self._graph, tracker=DanglingTracker()
-            )(obj, attr_var)
+            )(obj, attr_name_var)
         )
 
     def LOAD_CONST(self, instr: Instruction):

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -836,11 +836,14 @@ class OpcodeExecutorBase:
 
     def LOAD_METHOD(self, instr: Instruction):
         method_name = self._code.co_names[instr.arg]
+        method_name_var = ConstantVariable.wrap_literal(
+            method_name, self._graph
+        )
         obj = self.pop()
 
         method = BuiltinVariable(
             getattr, graph=self._graph, tracker=DanglingTracker()
-        )(obj, method_name)
+        )(obj, method_name_var)
 
         if isinstance(method, MethodVariable):
             # bound method, push the unbound method and the self

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -795,11 +795,12 @@ class OpcodeExecutorBase:
 
     def LOAD_ATTR(self, instr: Instruction):
         attr_name = self._code.co_names[instr.arg]
+        attr_var = ConstantVariable.wrap_literal(attr_name, self._graph)
         obj = self.pop()
         self.push(
             BuiltinVariable(
                 getattr, graph=self._graph, tracker=DanglingTracker()
-            )(obj, attr_name)
+            )(obj, attr_var)
         )
 
     def LOAD_CONST(self, instr: Instruction):

--- a/sot/opcode_translator/executor/variable_dispatch.py
+++ b/sot/opcode_translator/executor/variable_dispatch.py
@@ -267,12 +267,6 @@ Dispatcher.register(
     lambda var, other: var.repeat(other),
 )
 # getattr
-# TODO(SigureMo): Unify these to a single function
-Dispatcher.register(
-    getattr,
-    ("VariableBase", "str", optional("VariableBase")),
-    lambda var, name, default=None: var.getattr(name, default),
-)
 Dispatcher.register(
     getattr,
     ("VariableBase", "ConstantVariable", optional("VariableBase")),

--- a/sot/opcode_translator/executor/variables/base.py
+++ b/sot/opcode_translator/executor/variables/base.py
@@ -9,7 +9,7 @@ from ....utils import NameGenerator, get_unbound_method, log
 from ....utils.exceptions import InnerError, NotImplementException
 from ..guard import StringifyExpression, check_guard, union_free_vars
 from ..pycode_generator import PyCodeGen
-from ..tracker import DummyTracker, GetAttrTracker, GetItemTracker, Tracker
+from ..tracker import GetAttrTracker, GetItemTracker, Tracker
 
 if TYPE_CHECKING:
     from ..function_graph import FunctionGraph
@@ -324,14 +324,18 @@ class VariableBase:
         """
         return type(self.get_py_value())
 
-    def reconstruct(self, codegen: PyCodeGen):
-        if (
-            not isinstance(self.tracker, DummyTracker)
-            and self.tracker.is_traceable()
-        ):
+    def reconstruct(
+        self,
+        codegen: PyCodeGen,
+        *,
+        use_tracker: bool = True,
+        add_to_global_guarded_vars: bool = True,
+    ):
+        if self.tracker.is_traceable() and use_tracker:
             self.tracker.gen_instructions(codegen)
         else:
-            self.graph.add_global_guarded_variable(self)
+            if add_to_global_guarded_vars:
+                self.graph.add_global_guarded_variable(self)
             self._reconstruct(codegen)
 
     def _reconstruct(self, codegen: PyCodeGen):

--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -283,8 +283,6 @@ class TensorVariable(VariableBase):
         return f"{self.graph.OUT_VAR_PREFIX}{self.var_name}"
 
     def _reconstruct(self, codegen: PyCodeGen):
-        # TODO(SigureMo): move global guard to VariableBase
-        self.graph.add_global_guarded_variable(self)
         codegen.gen_load_fast(self.out_var_name)
 
     @check_guard

--- a/sot/opcode_translator/executor/variables/callable.py
+++ b/sot/opcode_translator/executor/variables/callable.py
@@ -210,7 +210,6 @@ class MethodVariable(CallableVariable):
         )
 
     def _reconstruct(self, pycode_gen):
-        self.graph.add_global_guarded_variable(self)
         assert self.method_name is not None
         self.tensor.reconstruct(pycode_gen)
         pycode_gen.gen_load_attr(self.method_name)

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -112,7 +112,6 @@ class ListVariable(ContainerVariable):
         return list
 
     def _reconstruct(self, codegen: PyCodeGen):
-        self.graph.add_global_guarded_variable(self)
         size = len(self)
         for idx in range(size):
             self[idx].reconstruct(codegen)
@@ -410,7 +409,6 @@ class TupleVariable(ContainerVariable):
         return tuple
 
     def _reconstruct(self, codegen: PyCodeGen):
-        self.graph.add_global_guarded_variable(self)
         size = len(self)
         for idx in range(size):
             self[idx].reconstruct(codegen)
@@ -647,8 +645,6 @@ class DictVariable(ContainerVariable):
 
     def _reconstruct(self, codegen: PyCodeGen):
         from .basic import ConstantVariable
-
-        self.graph.add_global_guarded_variable(self)
 
         size = len(self)
         for key in self.proxy.get_all().keys():


### PR DESCRIPTION
- 将 reconstruct global guard 逻辑放在 VariableBase 上，减少冗余代码
- guard 中过滤掉 ConstTracker，减少无用的 Tracker
- LOAD_ATTR 调用 getattr 时传入 `ConstantVariable` 而不是 `str`，减少一个 dispatch 逻辑