### PR TITLE
skip eval frame for `warnings` module

### DIFF
--- a/sot/opcode_translator/skip_files.py
+++ b/sot/opcode_translator/skip_files.py
@@ -31,6 +31,7 @@ import types
 import typing
 import unittest
 import uuid
+import warnings
 import weakref
 
 import _collections_abc
@@ -95,6 +96,7 @@ skip_file_names = {
         uuid,
         setuptools,
         distutils,
+        warnings,
     )
 }
 


### PR DESCRIPTION
昨天 PaddlePaddle/Paddle#55568 修改了 `Tensor.__index__` 代码导致基于 CI 挂了，因为该代码触发了 warning，而 warning 没有 skip，就模拟执行了……