### PR TITLE
strictly builtin types do not inherit

### DIFF
--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -126,7 +126,7 @@ class ConstantVariable(VariableBase):
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(value, ConstTypes):
+        if type(value) in ConstTypes:
             return ConstantVariable(value, graph, tracker)
         return None
 

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -375,7 +375,10 @@ class ListVariable(ContainerVariable):
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(value, list):
+        # Note(SigureMo): Why not use isinstance?
+        # Because user may define a class that inherit from list.
+        # We should convert it to ObjectVariable instead of ListVariable.
+        if type(value) is list:
             return ListVariable(value, graph=graph, tracker=tracker)
         return None
 
@@ -528,7 +531,7 @@ class TupleVariable(ContainerVariable):
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(value, tuple):
+        if type(value) is tuple:
             return TupleVariable(value, graph, tracker)
         return None
 
@@ -579,7 +582,7 @@ class RangeVariable(ContainerVariable):
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(value, range):
+        if type(value) is range:
             return RangeVariable(value, graph, tracker)
         return None
 
@@ -875,5 +878,5 @@ class DictVariable(ContainerVariable):
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if isinstance(value, dict):
+        if type(value) is dict:
             return DictVariable(value, graph=graph, tracker=tracker)

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import operator
+from collections import OrderedDict
 from functools import reduce
 from typing import TYPE_CHECKING, Any
 
@@ -878,5 +879,5 @@ class DictVariable(ContainerVariable):
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
-        if type(value) is dict:
+        if type(value) in (dict, OrderedDict):
             return DictVariable(value, graph=graph, tracker=tracker)


### PR DESCRIPTION
保证 builtin types 的 Variable `from_value` 不会转换继承后的 builtin type，比如 PaddlePaddle/Paddle#55554 新增的动转静单测 CallableList，在模拟执行的时候按理说也没啥问题，因为可以跑 VariableBase 上的 call 逻辑

但如果打断子图，再 reconstruct 传入下个函数，这个时候它就真的只是 list 了，这时候再调用就会报错了

因此继承自 list 等 builtin type 的 object 不应该转成 list，而是应该转成 ObjectVariable

本 PR 只解决了当前 CI 的一个问题，还有一个问题还没解决，应该还合不了