### PR TITLE
allow install in python3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "PaddleSOT"
 version = "0.0.1a0"
 description = "A Bytecode level Implementation of Symbolic OpCode Translator For PaddlePaddle"
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.7,<3.12"
 authors = [
     {name = "PaddlePaddle", email = "Paddle-better@baidu.com"},
 ]


### PR DESCRIPTION
由于 sot 仅支持 3.8-3.11，因此之前不允许在 3.7 安装

但 Paddle CI 目前仍有 3.7 环境，为了确保能在 Paddle 安装，允许在 3.7 安装，但仅仅支持安装，不代表允许在 3.7 使用，3.7 未做过适配，Python 3.7 已经在一个多月前 EOL 了，因此也不会专门适配