### PR TITLE
[SOT]Fix KeyError when guard is builtins.__dict__[tuple] == xx

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -172,6 +172,12 @@ class InstructionTranslatorCache:
                             )
                             return CustomCode(code, False)
                         else:
+                            for key in guard_fn.__globals__.keys():
+                                if key.startswith("__object"):
+                                    log(
+                                        2,
+                                        f"[Cache] meet global object: {key} : {guard_fn.__globals__[key]}\n",
+                                    )
                             log(
                                 2,
                                 f"[Cache]: Cache miss, Guard is {guard_fn.expr if hasattr(guard_fn, 'expr') else 'None'}\n",

--- a/sot/opcode_translator/executor/tracker.py
+++ b/sot/opcode_translator/executor/tracker.py
@@ -200,7 +200,7 @@ class BuiltinTracker(Tracker):
 
     def trace_value_from_frame(self) -> StringifyExpression:
         return StringifyExpression(
-            f"builtins.__dict__[{self.name}]", {"builtins": builtins}
+            f"builtins.__dict__['{self.name}']", {"builtins": builtins}
         )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
修复当guard为builtins.__dict__[tuple] == __object_xx时的语法错误。这个语法错误会导致cache无法命中