### PR TITLE
clean from_value

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -950,7 +950,7 @@ class OpcodeExecutorBase:
         ), f"OpExecutor want BUILD_LIST with size {list_size}, but current stack do not have enough elems."
         val_list = self.pop_n(list_size)
         self.push(
-            VariableFactory.from_value(
+            ListVariable(
                 val_list, graph=self._graph, tracker=DummyTracker(val_list)
             )
         )
@@ -962,7 +962,7 @@ class OpcodeExecutorBase:
         ), f"OpExecutor want BUILD_TUPLE with size {tuple_size}, but current stack do not have enough elems."
         val_tuple = self.pop_n(tuple_size)
         self.push(
-            VariableFactory.from_value(
+            TupleVariable(
                 tuple(val_tuple),
                 graph=self._graph,
                 tracker=DummyTracker(val_tuple),
@@ -980,9 +980,7 @@ class OpcodeExecutorBase:
             assert s.get_py_type() is str
             new_str += s.get_py_value()
         self.push(
-            VariableFactory.from_value(
-                new_str, self._graph, DummyTracker(str_list)
-            )
+            ConstantVariable(new_str, self._graph, DummyTracker(str_list))
         )
 
     @call_break_graph_decorator(push_n=1)
@@ -999,9 +997,7 @@ class OpcodeExecutorBase:
         slice_ = slice(*(x.get_py_value() for x in related_list))
 
         self.push(
-            VariableFactory.from_value(
-                slice_, self._graph, DummyTracker(related_list)
-            )
+            SliceVariable(slice_, self._graph, DummyTracker(related_list))
         )
 
     def build_map(
@@ -1461,9 +1457,7 @@ class OpcodeExecutorBase:
                 result = format(result, fmt_spec)
 
             self.push(
-                VariableFactory.from_value(
-                    result, self._graph, DummyTracker([value])
-                )
+                ConstantVariable(result, self._graph, DummyTracker([value]))
             )
         else:
             raise NotImplementException(
@@ -1980,7 +1974,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         ret = fn(*input_vars)
         # slice_variable is [:-1]
         slice_const = slice(None, -1, None)
-        slice_variable = VariableFactory.from_value(
+        slice_variable = SliceVariable(
             slice_const, self._graph, ConstTracker(slice_const)
         )
         for name, val in zip(inputs[:-1], ret[slice_variable]):

--- a/sot/opcode_translator/executor/variables/base.py
+++ b/sot/opcode_translator/executor/variables/base.py
@@ -451,16 +451,18 @@ class VariableBase:
         )
 
     def hasattr(self, name: str):
+        from .basic import ConstantVariable
+
         try:
             self.getattr(name)
-            return VariableFactory.from_value(
+            return ConstantVariable(
                 True, graph=self.graph, tracker=DummyTracker([self])
             )
         except HasNoAttributeError:
             # NOTE(SigureMo): Only the HasNoAttributeError is raised, we can
             # ensure that the attribute does not exist. Otherwise, we should
             # raise the error.
-            return VariableFactory.from_value(
+            return ConstantVariable(
                 False, graph=self.graph, tracker=DummyTracker([self])
             )
 

--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -401,15 +401,15 @@ class TensorVariable(VariableBase):
         return self.size
 
     def len(self):
-        if len(self.shape) == 0:
+        if len(self.meta.shape) == 0:
             raise InnerError("len() of a 0-D tensor is wrong")
-        first_dim = self.shape[0]
+        first_dim = self.meta.shape[0]
         if first_dim == -1:
             raise BreakGraphError(
                 "Getting len() for a dynamic shape tensor causes graph break."
             )
 
-        return first_dim
+        return ConstantVariable(first_dim, self.graph, DummyTracker([self]))
 
     def is_tensor(self):
         return VariableFactory.from_value(

--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -355,10 +355,10 @@ class TensorVariable(VariableBase):
         """
         Return a new TensorVariable object that wraps the result of calling the transpose method on the wrapped value of this TensorVariable.
         """
+        from .container import ListVariable
+
         perm = list(range(len(self.meta.shape) - 1, -1, -1))
-        perm_var = VariableFactory.from_value(
-            perm, self.graph, tracker=ConstTracker(perm)
-        )
+        perm_var = ListVariable(perm, self.graph, tracker=ConstTracker(perm))
         assert perm_var is not None
         out = self.graph.call_paddle_api(paddle.transpose, self, perm_var)
         return out
@@ -368,7 +368,7 @@ class TensorVariable(VariableBase):
         """
         Return a ConstantVariable object that represents the number of dimensions of the wrapped value of this TensorVariable.
         """
-        return VariableFactory.from_value(
+        return ConstantVariable(
             len(self.meta.shape), self.graph, DummyTracker([self])
         )
 
@@ -383,9 +383,7 @@ class TensorVariable(VariableBase):
                 f"Getting size for a dynamic shape tensor causes graph break. shape = {self.meta.shape}"
             )
         elements = reduce(operator.mul, self.meta.shape, 1)
-        return VariableFactory.from_value(
-            elements, self.graph, DummyTracker([self])
-        )
+        return ConstantVariable(elements, self.graph, DummyTracker([self]))
 
     @tensor_property
     def shape(self):
@@ -393,7 +391,9 @@ class TensorVariable(VariableBase):
             raise BreakGraphError(
                 f"Getting shape for a dynamic shape tensor causes graph break. shape = {self.meta.shape}"
             )
-        return VariableFactory.from_value(
+        from .container import ListVariable
+
+        return ListVariable(
             self.meta.shape, self.graph, tracker=DummyTracker([self])
         )
 
@@ -412,30 +412,22 @@ class TensorVariable(VariableBase):
         return ConstantVariable(first_dim, self.graph, DummyTracker([self]))
 
     def is_tensor(self):
-        return VariableFactory.from_value(
-            True, self.graph, DummyTracker([self])
-        )
+        return ConstantVariable(True, self.graph, DummyTracker([self]))
 
     def is_complex(self):
         dtype = self.meta.dtype
         is_cp_dtype = dtype in CP_DTYPE_ABBRS
-        return VariableFactory.from_value(
-            is_cp_dtype, self.graph, DummyTracker([self])
-        )
+        return ConstantVariable(is_cp_dtype, self.graph, DummyTracker([self]))
 
     def is_integer(self):
         dtype = self.meta.dtype
         is_int_dtype = dtype in INT_DTYPE_ABBRS
-        return VariableFactory.from_value(
-            is_int_dtype, self.graph, DummyTracker([self])
-        )
+        return ConstantVariable(is_int_dtype, self.graph, DummyTracker([self]))
 
     def is_floating_point(self):
         dtype = self.meta.dtype
         is_fp_dtype = dtype in FP_DTYPE_ABBRS
-        return VariableFactory.from_value(
-            is_fp_dtype, self.graph, DummyTracker([self])
-        )
+        return ConstantVariable(is_fp_dtype, self.graph, DummyTracker([self]))
 
     def getattr(self, name: str, default=None):
         if default is not None:

--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -108,46 +108,44 @@ class ConstantVariable(VariableBase):
         return bool(self.value)
 
     def bool(self):
-        return VariableFactory.from_value(
-            bool(self), self.graph, DummyTracker([self])
-        )
+        return ConstantVariable(bool(self), self.graph, DummyTracker([self]))
 
     def bool_not(self):
         assert isinstance(
             self.get_py_value(), bool
         ), "Bool_not can only be applied to a bool variable."
-        return VariableFactory.from_value(
+        return ConstantVariable(
             not bool(self.get_py_value()), self.graph, DummyTracker([self])
         )
 
     def str(self):
-        return VariableFactory.from_value(
+        return ConstantVariable(
             str(self.value), self.graph, DummyTracker([self])
         )
 
     def format(self, *args):
-        return VariableFactory.from_value(
+        return ConstantVariable(
             str(self.value).format(*[str(a.value) for a in args]),
             self.graph,
             DummyTracker([self, *args]),
         )
 
     def lower(self):
-        return VariableFactory.from_value(
+        return ConstantVariable(
             str(self.value).lower(),
             self.graph,
             DummyTracker([self]),
         )
 
     def ord(self):
-        return VariableFactory.from_value(
+        return ConstantVariable(
             ord(self.value),
             self.graph,
             DummyTracker([self]),
         )
 
     def chr(self):
-        return VariableFactory.from_value(
+        return ConstantVariable(
             chr(self.value),
             self.graph,
             DummyTracker([self]),
@@ -411,9 +409,7 @@ class TensorVariable(VariableBase):
                 "Getting len() for a dynamic shape tensor causes graph break."
             )
 
-        return VariableFactory.from_value(
-            first_dim, self.graph, DummyTracker([self])
-        )
+        return first_dim
 
     def is_tensor(self):
         return VariableFactory.from_value(

--- a/sot/opcode_translator/executor/variables/callable.py
+++ b/sot/opcode_translator/executor/variables/callable.py
@@ -529,9 +529,7 @@ class PaddleLayerVariable(LayerVariable):
         return len(self.value)
 
     def len(self):
-        return VariableFactory.from_value(
-            len(self), self.graph, DummyTracker([self])
-        )
+        return ConstantVariable(len(self), self.graph, DummyTracker([self]))
 
     def get_symbol(self) -> Symbol:
         return Symbol(self.name)


### PR DESCRIPTION
减少`from_value`转换次数, 提升🤏🏻性能

当我们能确定输出类型是一个确定的`Variable`的时候, 尽可能的少使用`from_value`转换数据类型，例如:
```python
def is_tensor(self):
    return VariableFactory.from_value(
        True, self.graph, DummyTracker([self])
    )
```
在这个🌰中`True`就是一个确定的`ConstantVariable`类型

因此我们可以把他初始化为
```python
def is_tensor(self):
    return ConstantVariable(
        True, self.graph, DummyTracker([self])
    )
```
