### PR TITLE
add side effect restore support for variable mutable attributes

### DIFF
--- a/sot/opcode_translator/executor/function_graph.py
+++ b/sot/opcode_translator/executor/function_graph.py
@@ -320,7 +320,7 @@ class FunctionGraph:
         # deal side effect
         self.restore_inplace_tensor(self._inplace_tensors)
         self.restore_print_stmts(self._print_variables)
-        self.restore_side_effects(self.side_effects.variables)
+        self.restore_side_effects(self.side_effects.proxy_variables)
         self.pycode_gen.gen_enable_eval_frame()
 
         tracker_output_path = show_trackers()
@@ -548,7 +548,7 @@ class FunctionGraph:
                     # Guard output that can not be traced.
                     self.add_global_guarded_variable(output)
         # Find Tensor Variables from side effects Variables.
-        for side_effect_var in self.side_effects.variables:
+        for side_effect_var in self.side_effects.proxy_variables:
             if side_effect_var.proxy.has_changed:
                 for var in side_effect_var.flatten_items():
                     if isinstance(var.tracker, DummyTracker) and isinstance(

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -935,6 +935,26 @@ class OpcodeExecutorBase:
             self.push(NullVariable())
             self.push(method)
 
+    def STORE_ATTR(self, instr):
+        obj = self.pop()
+        val = self.pop()
+        key = self._code.co_names[instr.arg]
+        if isinstance(obj, TensorVariable):
+            # support tensor variable store attr, like:
+            # t.stop_gradient = True
+            obj.graph.call_tensor_method(
+                "__setattr__",
+                obj,
+                VariableFactory().from_value(
+                    key, self._graph, ConstTracker(key)
+                ),
+                val,
+            )
+        else:
+            raise BreakGraphError(
+                f"STORE_ATTR don't support {type(obj)}.{key}={val}"
+            )
+
     def STORE_DEREF(self, instr):
         namemap = self._code.co_cellvars + self._code.co_freevars
         name = namemap[instr.arg]
@@ -2019,27 +2039,6 @@ class OpcodeExecutor(OpcodeExecutorBase):
         for name, val in zip(inputs[:-1], ret[slice_variable]):
             self._locals[name] = val
 
-    @call_break_graph_decorator(push_n=0)
-    def STORE_ATTR(self, instr):
-        obj = self.pop()
-        val = self.pop()
-        key = self._code.co_names[instr.arg]
-        if isinstance(obj, TensorVariable):
-            # support tensor variable store attr, like:
-            # t.stop_gradient = True
-            obj.graph.call_tensor_method(
-                "__setattr__",
-                obj,
-                VariableFactory().from_value(
-                    key, self._graph, ConstTracker(key)
-                ),
-                val,
-            )
-        else:
-            raise BreakGraphError(
-                f"STORE_ATTR don't support {type(obj)}.{key}={val}"
-            )
-
     def FOR_ITER(self, instr):
         iterator = self.pop()
         backup_iter_idx = None
@@ -2072,6 +2071,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
             self._graph.remove_global_guarded_variable(iterator)
             self._break_graph_in_for_loop(iterator, instr)
             return Stop()
+
+    @call_break_graph_decorator(push_n=0)
+    def STORE_ATTR(self, instr):
+        super().STORE_ATTR(instr)
 
     @call_break_graph_decorator(push_n=1)
     def CALL_FUNCTION(self, instr: Instruction):

--- a/sot/opcode_translator/executor/variables/base.py
+++ b/sot/opcode_translator/executor/variables/base.py
@@ -244,6 +244,7 @@ class VariableBase:
     name_generator = NameGenerator(
         "object_"
     )  # A class-level attribute to generate names for new variables
+    mutable_attrs = []
 
     def __init__(self, graph: FunctionGraph, tracker: Tracker):
         self.graph = graph

--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -274,6 +274,7 @@ class TensorVariable(VariableBase):
     """
 
     var_name_generator = NameGenerator("var_")
+    mutable_attrs = ["meta"]
 
     def __init__(
         self,
@@ -296,6 +297,7 @@ class TensorVariable(VariableBase):
             )
         self.origin_meta = self.meta
         self.var_name = TensorVariable.var_name_generator.next()
+        self.graph.side_effects.record_mutable_variable(self)
 
     def __len__(self):
         if self.meta.shape[0] == -1:
@@ -805,11 +807,11 @@ class GlobalVariable(VariableBase):
                 f"[{self.__class__.__name__}]: recieved {value} to set value."
             )
         self.proxy.set(key, value)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
 
     def delete(self, key):
         self.proxy.delete(key)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
 
 
 class FunctionGlobalVariable(GlobalVariable):

--- a/sot/opcode_translator/executor/variables/callable.py
+++ b/sot/opcode_translator/executor/variables/callable.py
@@ -464,8 +464,14 @@ class BuiltinVariable(FunctionVariable):
                 return fn_var(*args)
 
         # Break graph if neither of the above conditions is met
+        arg_types = ", ".join([type(arg).__name__ for arg in args])
+        fn_name = (
+            self.value.__name__
+            if hasattr(self.value, '__name__')
+            else self.value
+        )
         raise BreakGraphError(
-            f"Not support builtin function: {self.value.__name__ if hasattr(self.value, '__name__') else self.value}"
+            f"Not support builtin function: {fn_name} with args: Args({arg_types})"
         )
 
     @VariableFactory.register_from_value()

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -202,7 +202,7 @@ class ListVariable(ContainerVariable):
                 f"Unsupported key type {key.__class__.__name__} and value type {value.__class__.__name__} for ListVariable"
             )
 
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def __delitem__(self, key):
@@ -214,23 +214,23 @@ class ListVariable(ContainerVariable):
                 f"[{self.__class__.__name__}]: received {key} as key to delete."
             )
         self.proxy.delete(key)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def insert(self, index: int, value: VariableBase):
         self.proxy.insert(index, value)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def append(self, value: VariableBase):
         self.insert(self.proxy.length, value)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def extend(self, data):
         for item in data.proxy.get_all():
             self.append(item)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def concat(self, list_):
@@ -254,7 +254,7 @@ class ListVariable(ContainerVariable):
             index = ConstantVariable.wrap_literal(-1, self.graph)
         res = self.proxy.get(index.get_py_value())
         self.proxy.delete(index.get_py_value())
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return res
 
     def copy(self):
@@ -267,7 +267,7 @@ class ListVariable(ContainerVariable):
     def clear(self):
         for idx in range(self.proxy.length):
             self.delitem(0)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def remove(self, value):
@@ -279,7 +279,7 @@ class ListVariable(ContainerVariable):
                 break
         else:
             raise InnerError(f"List {self} does not contain {value}")
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def sort(self, key=None, reverse=None):
@@ -303,14 +303,14 @@ class ListVariable(ContainerVariable):
             reverse=reverse.get_py_value(),
         )
         self.proxy.permutate(permutation)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def reverse(self):
         permutation = list(range(self.proxy.length))
         permutation.reverse()
         self.proxy.permutate(permutation)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def count(self, value: VariableBase):
@@ -815,7 +815,7 @@ class DictVariable(ContainerVariable):
             )
 
         self.proxy.set(key, value)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
 
         return ConstantVariable.wrap_literal(None, self.graph)
 
@@ -823,7 +823,7 @@ class DictVariable(ContainerVariable):
         # TODO: Replace with self.proxy.clear()
         for key in self.value:
             self.delitem(key)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def __delitem__(self, key):
@@ -835,7 +835,7 @@ class DictVariable(ContainerVariable):
                 f"[{self.__class__.__name__}]: recieved {key} as key to delete."
             )
         self.proxy.delete(key)
-        self.graph.side_effects.record_variable(self)
+        self.graph.side_effects.record_proxy_variable(self)
         return ConstantVariable.wrap_literal(None, self.graph)
 
     def keys(self):

--- a/tests/test_12_for_loop.py
+++ b/tests/test_12_for_loop.py
@@ -8,6 +8,7 @@ import unittest
 from test_case_base import TestCaseBase, strict_mode_guard
 
 import paddle
+import sot
 from sot import symbolic_translate
 from sot.opcode_translator.executor.opcode_executor import (
     InstructionTranslatorCache,
@@ -119,7 +120,13 @@ def for_without_zero_iter(self_res_dict, output):
     return res_dict
 
 
-class TestExecutor(TestCaseBase):
+@sot.psdb.check_no_fallback
+def for_reconstruct_range_iter():
+    for i in range(3):
+        sot.psdb.breakgraph()
+
+
+class TestForLoop(TestCaseBase):
     def test_list(self):
         a = paddle.to_tensor(1)
         self.assert_results(for_list_1, a)
@@ -172,10 +179,13 @@ class TestExecutor(TestCaseBase):
         paddle_output = for_create_tmp_in_loop(x, iter(a))
         self.assert_nest_match(sym_output, paddle_output)
 
-    def test(self):
+    def test_for_without_zero_iter(self):
         self_res_dict = {}
         output = paddle.to_tensor(2)
         self.assert_results(for_without_zero_iter, self_res_dict, output)
+
+    def test_reconstruct_range_iter(self):
+        self.assert_results(for_reconstruct_range_iter)
 
 
 def run_list_comp(x):


### PR DESCRIPTION
增加 variable 可变属性 side effect 的恢复

注意该恢复仅为模拟执行 inline call 阶段的恢复，即模拟执行状态发生的 side effect 的恢复，不包含生成恢复代码，因为它对外界没有影响

其他修改

- 移动 `STORE_ATTR` 到 `OpCodeExecutorBase`
- 优化 builtin 不支持打断的情况的 log，添加参数类型名