### PR TITLE
[Compat][3.11] enable test03-06 for python 3.11

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -762,6 +762,11 @@ class OpcodeExecutorBase:
         ), f"dangling variable {val} should not be pushed into stack."
         self._stack.append(val)
 
+    def COPY(self, instr: Instruction):
+        assert isinstance(instr.arg, int)
+        assert instr.arg > 0
+        self.push(self._stack[-instr.arg])
+
     def DUP_TOP(self, instr: Instruction):
         self.push(self.peek())
 
@@ -797,6 +802,13 @@ class OpcodeExecutorBase:
     def RESUME(self, instr: Instruction):
         # RESUME is a no-op, it just for internal tracing, debugging and optimization checks.
         pass
+
+    def SWAP(self, instr: Instruction):
+        assert isinstance(instr.arg, int)
+        assert instr.arg > 0
+        top = self.peek()
+        self._stack[-1] = self._stack[-instr.arg]
+        self._stack[-instr.arg] = top
 
     # unary operators
     UNARY_POSITIVE = tos_op_wrapper(operator.pos)
@@ -2118,6 +2130,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
     @call_break_graph_decorator(push_n=0)
     def STORE_ATTR(self, instr):
         super().STORE_ATTR(instr)
+
+    @call_break_graph_decorator(push_n=1)
+    def CALL(self, instr: Instruction):
+        super().CALL(instr)
 
     @call_break_graph_decorator(push_n=1)
     def CALL_FUNCTION(self, instr: Instruction):

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -906,7 +906,7 @@ class OpcodeExecutorBase:
             namei >>= 1
         if push_null:
             self.push(NullVariable())
-        name = self._code.co_names[instr.arg]
+        name = self._code.co_names[namei]
         if name in self._globals.keys():
             value = self._globals.get(name)
         elif name in self._builtins.keys():
@@ -1141,6 +1141,9 @@ class OpcodeExecutorBase:
                 retval, self._graph, DummyTracker(unpack_values)
             )
         )
+
+    def PRECALL(self, instr: Instruction):
+        ...
 
     def CALL_FUNCTION(self, instr: Instruction):
         n_args = instr.arg

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -12,18 +12,15 @@ py311_skiped_tests=(
     # ./test_03_tuple.py            There are some case need to be fixed
     # ./test_04_list.py             There are some case need to be fixed
     # ./test_05_dict.py             There are some case need to be fixed
-    ./test_09_f_string.py
     ./test_10_build_unpack.py
     ./test_11_jumps.py
     ./test_12_for_loop.py
     ./test_13_make_function.py
     ./test_14_operators.py
     ./test_15_slice.py
-    ./test_16_paddle_api.py
     ./test_17_paddle_layer.py
     ./test_18_tensor_method.py
     ./test_19_closure.py
-    ./test_20_string.py
     ./test_21_global.py
     ./test_analysis_inputs.py
     ./test_break_graph.py

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -8,10 +8,10 @@ echo "IS_PY311:" $IS_PY311
 failed_tests=()
 
 py311_skiped_tests=(
-    # ./test_01_basic.py TestNumpyAdd also need to be fixed
-    ./test_03_tuple.py
-    ./test_04_list.py
-    ./test_05_dict.py
+    # ./test_01_basic.py            There are some case need to be fixed
+    # ./test_03_tuple.py            There are some case need to be fixed
+    # ./test_04_list.py             There are some case need to be fixed
+    # ./test_05_dict.py             There are some case need to be fixed
     ./test_06_call_function.py
     ./test_09_f_string.py
     ./test_10_build_unpack.py

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -12,7 +12,6 @@ py311_skiped_tests=(
     # ./test_03_tuple.py            There are some case need to be fixed
     # ./test_04_list.py             There are some case need to be fixed
     # ./test_05_dict.py             There are some case need to be fixed
-    ./test_06_call_function.py
     ./test_09_f_string.py
     ./test_10_build_unpack.py
     ./test_11_jumps.py

--- a/tests/test_02_store_inplace.py
+++ b/tests/test_02_store_inplace.py
@@ -12,7 +12,7 @@ def foo(x: int, y: paddle.Tensor):
     return x
 
 
-class TestExecutor(TestCaseBase):
+class TestStoreInplace(TestCaseBase):
     def test_simple(self):
         self.assert_results(foo, 1, paddle.to_tensor(2))
 

--- a/tests/test_03_tuple.py
+++ b/tests/test_03_tuple.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import sys
 import unittest
 
 from test_case_base import TestCaseBase
@@ -50,7 +51,7 @@ def tuple_index_tensor(x: paddle.Tensor, y: tuple[paddle.Tensor]):
     return y.index(x)
 
 
-class TestTuple(TestCaseBase):
+class TestBuildTuple(TestCaseBase):
     def test_build_tuple(self):
         self.assert_results(build_tuple, 1, paddle.to_tensor(2))
         self.assert_results(
@@ -60,6 +61,11 @@ class TestTuple(TestCaseBase):
             build_tuple_with_int_subscript, 1, paddle.to_tensor(2)
         )
 
+
+@unittest.skipIf(
+    sys.version_info >= (3, 11), "Python 3.11+ is not supported yet."
+)
+class TestTupleMethods(TestCaseBase):
     def test_tuple_methods_int(self):
         self.assert_results(tuple_count_int, 1, paddle.to_tensor(2))
         self.assert_results(tuple_index_int, 1, paddle.to_tensor(2))

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -5,23 +5,28 @@
 
 from __future__ import annotations
 
+import sys
 import unittest
 
 from test_case_base import TestCaseBase
 
 import paddle
+from sot.psdb import check_no_breakgraph
 
 
+@check_no_breakgraph
 def list_getitem_int(x: int, y: paddle.Tensor):
     x = [x, y]
     return x[0] + 1
 
 
+@check_no_breakgraph
 def list_getitem_tensor(x: int, y: paddle.Tensor):
     x = [x, y]
     return x[1] + 1
 
 
+@check_no_breakgraph
 def list_setitem_int(x: int, y: paddle.Tensor):
     z = [x, y]
     z[0] = 3
@@ -34,41 +39,48 @@ def list_setitem_tensor(x: int, y: paddle.Tensor):
     return z
 
 
+@check_no_breakgraph
 def list_delitem_int(x: int, y: paddle.Tensor):
     z = [x, y]
     del z[0]
     return z
 
 
+@check_no_breakgraph
 def list_delitem_tensor(x: int, y: paddle.Tensor):
     z = [x, y]
     del z[1]
     return z
 
 
+@check_no_breakgraph
 def list_construct_from_list(x: int, y: paddle.Tensor):
     z = [x, y]
     return z
 
 
+@check_no_breakgraph
 def list_append_int(x: int, y: paddle.Tensor):
     z = [x, y]
     z.append(3)
     return z
 
 
+@check_no_breakgraph
 def list_append_tensor(x: int, y: paddle.Tensor):
     z = [x, y]
     z.append(y)
     return z
 
 
+@check_no_breakgraph
 def list_clear(x: int, y: paddle.Tensor):
     z = [x, y]
     z.clear()
     return z
 
 
+@check_no_breakgraph
 def list_copy(x: int, y: paddle.Tensor):
     z = [x, y]
     a = z.copy()
@@ -77,6 +89,7 @@ def list_copy(x: int, y: paddle.Tensor):
     return (a, z)
 
 
+@check_no_breakgraph
 def list_count_int(x: int, y: paddle.Tensor):
     z = [x, x, 2, 3, 1]
     return z.count(x)
@@ -86,6 +99,7 @@ def list_count_tensor(x: paddle.Tensor, y: list[paddle.Tensor]):
     return y.count(x)
 
 
+@check_no_breakgraph
 def list_extend(x: int, y: paddle.Tensor):
     z = [x, y]
     a = [y, x]
@@ -95,6 +109,7 @@ def list_extend(x: int, y: paddle.Tensor):
     return z
 
 
+@check_no_breakgraph
 def list_index_int(x: int, y: paddle.Tensor):
     z = [x, x, 1, 2]
     return z.index(x)
@@ -104,6 +119,7 @@ def list_index_tensor(x: paddle.Tensor, y: list[paddle.Tensor]):
     return y.index(x)
 
 
+@check_no_breakgraph
 def list_insert(x: int, y: paddle.Tensor):
     z = [x, y]
     z.insert(0, x)
@@ -111,6 +127,7 @@ def list_insert(x: int, y: paddle.Tensor):
     return z
 
 
+@check_no_breakgraph
 def list_pop(x: int, y: paddle.Tensor):
     z = [x, y]
     a = z.pop()
@@ -118,6 +135,7 @@ def list_pop(x: int, y: paddle.Tensor):
     return (z, a, b)
 
 
+@check_no_breakgraph
 def list_remove(x: int, y: paddle.Tensor):
     z = [x, x, y, y]
     z.remove(x)
@@ -125,54 +143,64 @@ def list_remove(x: int, y: paddle.Tensor):
     return z
 
 
+@check_no_breakgraph
 def list_reverse(x: int, y: paddle.Tensor):
     z = [x, x, y, y]
     z.reverse()
     return z
 
 
+@check_no_breakgraph
 def list_default_sort(x: int, y: paddle.Tensor):
     z = [x + 2, x, x + 1]
     z.sort()
     return z
 
 
+@check_no_breakgraph
 def list_key_sort(x: int, y: paddle.Tensor):
     z = [x + 2, x, x + 1]
     z.sort(lambda x: x)
     return z
 
 
+@check_no_breakgraph
 def list_reverse_sort(x: int, y: paddle.Tensor):
     z = [x + 2, x, x + 1]
     z.sort(reverse=True)
     return z
 
 
+@check_no_breakgraph
 def list_tensor_sort(x: int, y: paddle.Tensor):
     z = [y + 2, y, y + 1]
     z.sort()
     return z
 
 
+@check_no_breakgraph
 def list_max(x: paddle.Tensor | int, y: paddle.Tensor | int):
     z = [x, x, y]
     return max(z)
 
 
+@check_no_breakgraph
 def list_tensor_max_api(x: paddle.Tensor):
     return x.max()
 
 
+@check_no_breakgraph
 def list_min(x: paddle.Tensor | int, y: paddle.Tensor | int):
     z = [x, x, y]
     return min(z)
 
 
+@check_no_breakgraph
 def list_tensor_min_api(x: paddle.Tensor):
     return x.min()
 
 
+@check_no_breakgraph
 def list_no_arguments():
     l1 = list()  # noqa: C408
     l1.append(1)
@@ -181,54 +209,83 @@ def list_no_arguments():
     return l1[0] + l2[0]
 
 
-class TestList(TestCaseBase):
-    def test_simple(self):
+class TestListBasic(TestCaseBase):
+    def test_list_basic(self):
         self.assert_results(list_getitem_int, 1, paddle.to_tensor(2))
         self.assert_results(list_getitem_tensor, 1, paddle.to_tensor(2))
         self.assert_results_with_side_effects(
             list_setitem_int, 1, paddle.to_tensor(2)
         )
+
+
+@unittest.skipIf(
+    sys.version_info >= (3, 11), "Python 3.11+ is not supported yet."
+)
+class TestListMethods(TestCaseBase):
+    def test_list_setitem(self):
         self.assert_results_with_side_effects(
             list_setitem_tensor, 1, paddle.to_tensor(2)
         )
+
+    def test_list_count_and_index(self):
         self.assert_results(list_count_int, 1, paddle.to_tensor(2))
         self.assert_results(list_index_int, 1, paddle.to_tensor(2))
         a = paddle.to_tensor(1)
         b = paddle.to_tensor(2)
         self.assert_results(list_count_tensor, a, [a, b, a, b, a, b])
         self.assert_results(list_index_tensor, b, [a, b, a, b, a, b])
+
+    def test_list_delitem(self):
         self.assert_results_with_side_effects(
             list_delitem_int, 1, paddle.to_tensor(2)
         )
         self.assert_results_with_side_effects(
             list_delitem_tensor, 1, paddle.to_tensor(2)
         )
+
+    def test_list_append(self):
         self.assert_results_with_side_effects(
             list_append_int, 1, paddle.to_tensor(2)
         )
         self.assert_results_with_side_effects(
             list_append_tensor, 1, paddle.to_tensor(2)
         )
+
+    def test_list_clear(self):
         self.assert_results_with_side_effects(
             list_clear, 1, paddle.to_tensor(2)
         )
+
+    def test_list_copy(self):
         self.assert_results_with_side_effects(list_copy, 1, paddle.to_tensor(2))
+
+    def test_list_extend(self):
         self.assert_results_with_side_effects(
             list_extend, 1, paddle.to_tensor(2)
         )
+
+    def test_list_insert(self):
         self.assert_results_with_side_effects(
             list_insert, 1, paddle.to_tensor(2)
         )
+
+    def test_list_pop(self):
         self.assert_results_with_side_effects(list_pop, 1, paddle.to_tensor(2))
+
+    def test_list_remove(self):
         self.assert_results_with_side_effects(
             list_remove, 1, paddle.to_tensor(2)
         )
+
+    def test_list_reverse(self):
         self.assert_results_with_side_effects(
             list_reverse, 1, paddle.to_tensor(2)
         )
         self.assert_results_with_side_effects(
             list_reverse, 1, paddle.to_tensor(2)
         )
+
+    def test_list_sort(self):
         self.assert_results_with_side_effects(
             list_default_sort, 1, paddle.to_tensor(2)
         )
@@ -242,7 +299,11 @@ class TestList(TestCaseBase):
         # self.assert_results_with_side_effects(
         #     list_reverse_sort, 1, paddle.to_tensor(2)
         # )
+
+    def test_list_construct_from_list(self):
         self.assert_results(list_construct_from_list, 1, paddle.to_tensor(2))
+
+    def test_list_max_min(self):
         self.assert_results(list_max, 1, 2)
         self.assert_results(list_min, 1, 2)
         self.assert_results(list_tensor_max_api, paddle.to_tensor([1, 2, 3]))

--- a/tests/test_05_dict.py
+++ b/tests/test_05_dict.py
@@ -2,33 +2,40 @@
 # BUILD_MAP (new)
 # BUILD_CONST_KEY_MAP (new)
 
+import sys
 import unittest
 
 from test_case_base import TestCaseBase
 
 import paddle
+from sot.psdb import check_no_breakgraph
 
 
+@check_no_breakgraph
 def build_map(x: int, y: paddle.Tensor):
     z = {x: y}
     return z[x] + 1
 
 
+@check_no_breakgraph
 def build_const_key_map(x: int, y: paddle.Tensor):
     z = {1: y, 2: y + 1}
     return z[x] + 1
 
 
+@check_no_breakgraph
 def dict_get_item(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     return (z.get(1), z.get(2))
 
 
+@check_no_breakgraph
 def dict_get_item_default(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     return (z.get(3, 2), z.get(4, y))
 
 
+@check_no_breakgraph
 def dict_set_item_int(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     z[1] = x * 2
@@ -41,37 +48,43 @@ def dict_set_item_tensor(x: int, y: paddle.Tensor):
     return z[1]
 
 
+@check_no_breakgraph
 def dict_update_item1(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     z.update({1: x * 2, 2: y, 3: y + 2})
     return z
 
 
+@check_no_breakgraph
 def dict_update_item2(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     z.update({1: x * 2, 2: y, 3: z[2] + 2})
     return z
 
 
+@check_no_breakgraph
 def dict_del_item_int(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     del z[1]
     return z
 
 
+@check_no_breakgraph
 def dict_del_item_tensor(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     del z[2]
     return z
 
 
-def dict_clean_item(x: int, y: paddle.Tensor):
+@check_no_breakgraph
+def dict_clear(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     z.clear()
     return z
 
 
-def dict_copy_item(x: int, y: paddle.Tensor):
+@check_no_breakgraph
+def dict_copy(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     z2 = z.copy()
     z[1] = 2
@@ -93,6 +106,7 @@ def dict_fromkeys_nodefault(x: int, y: paddle.Tensor):
     return z
 
 
+@check_no_breakgraph
 def dict_setdefault_int(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1}
     a = z.setdefault(4)
@@ -101,6 +115,7 @@ def dict_setdefault_int(x: int, y: paddle.Tensor):
     return (z, a, b, c)
 
 
+@check_no_breakgraph
 def dict_pop(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1, 3: y}
     a = z.pop(1)
@@ -110,6 +125,7 @@ def dict_pop(x: int, y: paddle.Tensor):
     return (z, a, b, c, d)
 
 
+@check_no_breakgraph
 def dict_popitem(x: int, y: paddle.Tensor):
     z = {1: x, 2: y + 1, 3: y}
     a = z.popitem()
@@ -134,12 +150,14 @@ def dict_construct_from_tuple():
     return d
 
 
+@check_no_breakgraph
 def dict_construct_from_comprehension():
     z = {1: 2, 3: 4}
     d = {k: v + 1 for k, v in z.items()}
     return d
 
 
+@check_no_breakgraph
 def dict_no_arguments():
     d1 = dict()  # noqa: C408
     d1.update({1: 2})
@@ -148,12 +166,19 @@ def dict_no_arguments():
     return d1[1] + d2[3]
 
 
-class TestDict(TestCaseBase):
+class TestBuildDict(TestCaseBase):
     def test_build_map(self):
         self.assert_results(build_map, 1, paddle.to_tensor(2))
 
     def test_build_const_key_map(self):
         self.assert_results(build_const_key_map, 1, paddle.to_tensor(2))
+
+
+@unittest.skipIf(
+    sys.version_info >= (3, 11), "Python 3.11+ is not supported yet."
+)
+class TestDictMethods(TestCaseBase):
+    def test_dict_get_item(self):
         self.assert_results(dict_get_item, 1, paddle.to_tensor(2))
         self.assert_results(dict_get_item_default, 1, paddle.to_tensor(2))
 
@@ -164,9 +189,11 @@ class TestDict(TestCaseBase):
         self.assert_results_with_side_effects(
             dict_set_item_tensor, 1, paddle.to_tensor(2)
         )
-        self.assert_results_with_side_effects(
-            dict_copy_item, 1, paddle.to_tensor(2)
-        )
+
+    def test_dict_copy(self):
+        self.assert_results_with_side_effects(dict_copy, 1, paddle.to_tensor(2))
+
+    def test_dict_fromkeys(self):
         self.assert_results_with_side_effects(
             dict_fromkeys_int, 1, paddle.to_tensor(2)
         )
@@ -176,12 +203,16 @@ class TestDict(TestCaseBase):
         self.assert_results_with_side_effects(
             dict_fromkeys_nodefault, 1, paddle.to_tensor(2)
         )
+
+    def test_dict_update(self):
         self.assert_results_with_side_effects(
             dict_update_item1, 1, paddle.to_tensor(2)
         )
         self.assert_results_with_side_effects(
             dict_update_item2, 1, paddle.to_tensor(2)
         )
+
+    def test_dict_setdefault(self):
         self.assert_results_with_side_effects(
             dict_setdefault_int, 1, paddle.to_tensor(2)
         )
@@ -193,10 +224,16 @@ class TestDict(TestCaseBase):
         self.assert_results_with_side_effects(
             dict_del_item_tensor, 1, paddle.to_tensor(2)
         )
+
+    def test_dict_clear(self):
         self.assert_results_with_side_effects(
-            dict_clean_item, 1, paddle.to_tensor(2)
+            dict_clear, 1, paddle.to_tensor(2)
         )
+
+    def test_dict_pop(self):
         self.assert_results_with_side_effects(dict_pop, 1, paddle.to_tensor(2))
+
+    def test_dict_popitem(self):
         self.assert_results_with_side_effects(
             dict_popitem, 1, paddle.to_tensor(2)
         )

--- a/tests/test_06_call_function.py
+++ b/tests/test_06_call_function.py
@@ -113,26 +113,26 @@ class TestCall(TestCaseBase):
     def test_call1(self):
         self.assert_results(foo_1, paddle.to_tensor(2))
 
-    # def test_call2(self):
-    #     self.assert_results(foo_2, paddle.to_tensor(3))
+    def test_call2(self):
+        self.assert_results(foo_2, paddle.to_tensor(3))
 
-    # def test_call3(self):
-    #     self.assert_results(foo_3, paddle.to_tensor(4))
+    def test_call3(self):
+        self.assert_results(foo_3, paddle.to_tensor(4))
 
-    # def test_call4(self):
-    #     self.assert_results(foo_4, paddle.to_tensor(5))
+    def test_call4(self):
+        self.assert_results(foo_4, paddle.to_tensor(5))
 
-    # def test_call5(self):
-    #     self.assert_results(foo_5, paddle.to_tensor(6))
+    def test_call5(self):
+        self.assert_results(foo_5, paddle.to_tensor(6))
 
-    # def test_call6(self):
-    #     self.assert_results(foo_6, paddle.to_tensor(7))
+    def test_call6(self):
+        self.assert_results(foo_6, paddle.to_tensor(7))
 
-    # def test_call7(self):
-    #     self.assert_results(foo_7, paddle.to_tensor(8))
+    def test_call7(self):
+        self.assert_results(foo_7, paddle.to_tensor(8))
 
-    # def test_call8(self):
-    #     self.assert_results(foo_8, paddle.to_tensor(9))
+    def test_call8(self):
+        self.assert_results(foo_8, paddle.to_tensor(9))
 
 
 if __name__ == "__main__":

--- a/tests/test_06_call_function.py
+++ b/tests/test_06_call_function.py
@@ -109,16 +109,30 @@ def foo_8(x: paddle.Tensor):
     return m
 
 
-class TestExecutor(TestCaseBase):
-    def test_simple(self):
+class TestCall(TestCaseBase):
+    def test_call1(self):
         self.assert_results(foo_1, paddle.to_tensor(2))
-        self.assert_results(foo_2, paddle.to_tensor(3))
-        self.assert_results(foo_3, paddle.to_tensor(4))
-        self.assert_results(foo_4, paddle.to_tensor(5))
-        self.assert_results(foo_5, paddle.to_tensor(6))
-        self.assert_results(foo_6, paddle.to_tensor(7))
-        self.assert_results(foo_7, paddle.to_tensor(8))
-        self.assert_results(foo_8, paddle.to_tensor(9))
+
+    # def test_call2(self):
+    #     self.assert_results(foo_2, paddle.to_tensor(3))
+
+    # def test_call3(self):
+    #     self.assert_results(foo_3, paddle.to_tensor(4))
+
+    # def test_call4(self):
+    #     self.assert_results(foo_4, paddle.to_tensor(5))
+
+    # def test_call5(self):
+    #     self.assert_results(foo_5, paddle.to_tensor(6))
+
+    # def test_call6(self):
+    #     self.assert_results(foo_6, paddle.to_tensor(7))
+
+    # def test_call7(self):
+    #     self.assert_results(foo_7, paddle.to_tensor(8))
+
+    # def test_call8(self):
+    #     self.assert_results(foo_8, paddle.to_tensor(9))
 
 
 if __name__ == "__main__":

--- a/tests/test_09_f_string.py
+++ b/tests/test_09_f_string.py
@@ -18,8 +18,8 @@ def foo(x: paddle.Tensor):
     return x
 
 
-class TestExecutor(TestCaseBase):
-    def test_simple(self):
+class TestFString(TestCaseBase):
+    def test_fstring(self):
         self.assert_results(foo, paddle.to_tensor(1))
 
 


### PR DESCRIPTION
开始推进 Python 3.11 支持

部分文件因为后来引入了一些复杂 case，会影响渐进性支持，因此将复杂 case 在 3.11 暂时 skip 掉，之后支持

发现了一些问题，比如 dict 下的一些方法无法装饰 `check_no_breakgraph`