### PR TITLE
[ci] fix abnormal cancellation

### DIFF
--- a/.github/workflows/paddle_ci.yaml
+++ b/.github/workflows/paddle_ci.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # RAM too small, Related link: https://github.com/actions/runner-images/discussions/7188
       - name: Increase swapfile
         run: |
           sudo swapoff -a

--- a/.github/workflows/paddle_ci.yaml
+++ b/.github/workflows/paddle_ci.yaml
@@ -19,6 +19,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Increase swapfile
+        run: |
+          sudo swapoff -a
+          sudo fallocate -l 15G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapon --show
+
       - name: Install python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
修复`ci`异常取消
```bash
2023-08-24T13:50:07.0777496Z ##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
2023-08-24T13:50:07.5084517Z ##[error]The operation was canceled.
2023-08-24T13:50:07.6361032Z Cleaning up orphan processes
```

相关的一些讨论:
 * https://github.com/actions/runner-images/discussions/7188