### PR TITLE
[refactor] use VariableStack instead of list

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -531,7 +531,7 @@ def jump_break_graph_decorator(normal_jump):
     """
 
     def inner(self: OpcodeExecutor, instr: Instruction):
-        result = self.stack.peek()
+        result = self.stack.top
         if isinstance(result, TensorVariable):
             self.stack.pop()
             # fallback when in OpcodeExecutor
@@ -855,7 +855,7 @@ class OpcodeExecutorBase:
         self.stack.push(self.stack.top)
 
     def DUP_TOP_TWO(self, instr: Instruction):
-        for ref in self.stack.peek(2):
+        for ref in self.stack.peek[:2]:
             self.stack.push(ref)
 
     def _rot_top_n(self, n):
@@ -1492,7 +1492,7 @@ class OpcodeExecutorBase:
 
     @jump_break_graph_decorator
     def JUMP_IF_FALSE_OR_POP(self, instr: Instruction):
-        pred_obj = self.stack.peek()
+        pred_obj = self.stack.top
         if isinstance(pred_obj, (ConstantVariable, ContainerVariable)):
             self._graph.add_global_guarded_variable(pred_obj)
             is_jump = not bool(pred_obj)
@@ -1507,7 +1507,7 @@ class OpcodeExecutorBase:
 
     @jump_break_graph_decorator
     def JUMP_IF_TRUE_OR_POP(self, instr: Instruction):
-        pred_obj = self.stack.peek()
+        pred_obj = self.stack.top
         if isinstance(pred_obj, (ConstantVariable, ContainerVariable)):
             self._graph.add_global_guarded_variable(pred_obj)
             is_jump = bool(pred_obj)

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -115,7 +115,7 @@ class VariableStack:
     A stack class for storing variables.
 
     Examples:
-        >>> var1, var2, var3, var4 = (VariableFactory.create_variables(1) for _ in range(4))
+        >>> var1, var2, var3, var4 = (ConstantVariable.wrap_literal(i, None) for i in range(4))
         >>> stack = VariableStack()
         >>> stack.push(var1)
         >>> stack.push(var2)

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -121,27 +121,27 @@ class VariableStack:
         >>> stack.push(var2)
         >>> stack.push(var3)
         >>> stack
-        [var1, var2, var3]
+        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
         >>> stack.pop()
-        var3
+        ConstantVariable(2, 2, object_6)
         >>> stack.pop_n(2)
-        [var1, var2]
+        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5)]
         >>> stack.push(var1)
         >>> stack.push(var2)
         >>> stack.push(var3)
         >>> stack
-        [var1, var2, var3]
+        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
         >>> stack.top
-        var3
+        ConstantVariable(2, 2, object_6)
         >>> stack.peek[1]
-        var3
+        ConstantVariable(2, 2, object_6)
         >>> stack.peek[:1]
-        [var3]
+        [ConstantVariable(2, 2, object_6)]
         >>> stack.peek[:2]
-        [var2, var3]
+        [ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
         >>> stack.peek[1] = var4
         >>> stack
-        [var1, var2, var4]
+        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(3, 3, object_7)]
 
     """
 

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -222,7 +222,7 @@ class VariableStack:
         """
         assert index >= 0
         self.validate_value(val)
-        self._data.insert(len(self)-index, val)
+        self._data.insert(len(self) - index, val)
 
     def pop(self) -> VariableBase:
         """
@@ -906,7 +906,10 @@ class OpcodeExecutorBase:
 
     def SWAP(self, instr: Instruction):
         assert isinstance(instr.arg, int)
-        self.stack.top, self.stack.peek[instr.arg] = self.stack.top, self.stack.peek[instr.arg]
+        self.stack.top, self.stack.peek[instr.arg] = (
+            self.stack.top,
+            self.stack.peek[instr.arg],
+        )
 
     # unary operators
     UNARY_POSITIVE = tos_op_wrapper(operator.pos)
@@ -1338,7 +1341,7 @@ class OpcodeExecutorBase:
 
         # split arg_list to args and kwargs
         arg_list = self.stack.pop_n(n_args)
-        args = arg_list[:-len(kwargs_keys)]
+        args = arg_list[: -len(kwargs_keys)]
         kwargs_values = arg_list[-len(kwargs_keys) :]
         kwargs = dict(zip(kwargs_keys, kwargs_values))
 

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -890,7 +890,7 @@ class OpcodeExecutorBase:
     def SWAP(self, instr: Instruction):
         assert isinstance(instr.arg, int)
         assert isinstance(instr.arg, int)
-        top = self.stack.peek()
+        top = self.stack.top
         self.top = self.stack.peek[instr.arg]
         self.stack.peek[instr.arg] = top
 

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -115,6 +115,7 @@ class VariableStack:
     A stack class for storing variables.
 
     Examples:
+        >>> var1, var2, var3, var4 = (var for var in VariableFactory.create_variables(1))
         >>> stack = VariableStack()
         >>> stack.push(var1)
         >>> stack.push(var2)

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -115,7 +115,7 @@ class VariableStack:
     A stack class for storing variables.
 
     Examples:
-        >>> var1, var2, var3, var4 = (var for var in VariableFactory.create_variables(1))
+        >>> var1, var2, var3, var4 = (VariableFactory.create_variables(1) for _ in range(4))
         >>> stack = VariableStack()
         >>> stack.push(var1)
         >>> stack.push(var2)

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -117,9 +117,9 @@ class VariableStack:
     Examples:
         >>> var1, var2, var3, var4 = (ConstantVariable.wrap_literal(i, None) for i in range(4))
         >>> stack = VariableStack()
-        >>> stack.push(var1)
-        >>> stack.push(var2)
+        >>> stack.push(var1)  # stack.insert(0, var1)
         >>> stack.push(var3)
+        >>> stack.insert(1, var2)
         >>> stack
         [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
         >>> stack.pop()
@@ -196,21 +196,33 @@ class VariableStack:
 
     def copy(self):
         return VariableStack(self._data.copy())
+    
+    # def swap(self):
+    #     return VariableStack(self._data.copy())
 
     def push(self, val: VariableBase):
         """
-        Pushes a value onto the stack.
+        Pushes a variable onto the stack.
 
         Args:
-            val: The value to be pushed.
+            val: The variable to be pushed.
 
         """
         self.validate_value(val)
         self._data.append(val)
 
     def insert(self, index: int, val: VariableBase):
+        """
+        Inserts a variable onto the stack.
+
+        Args:
+            index: The index at which the variable is to be inserted, the top of the stack is at index 0.
+            val: The variable to be inserted.
+
+        """
+        assert index >= 0
         self.validate_value(val)
-        self._data.insert(index, val)
+        self._data.insert(len(self)-index, val)
 
     def pop(self) -> VariableBase:
         """
@@ -872,7 +884,7 @@ class OpcodeExecutorBase:
             len(self.stack) >= n
         ), f"There are not enough elements on the stack. {n} is needed."
         top = self.stack.pop()
-        self.stack.insert(-(n - 1), top)
+        self.stack.insert(n - 1, top)
 
     def POP_TOP(self, instr: Instruction):
         self.stack.pop()

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -852,7 +852,7 @@ class OpcodeExecutorBase:
         self.stack.push(self.stack.peek[instr.arg])
 
     def DUP_TOP(self, instr: Instruction):
-        self.stack.push(self.stack.peek())
+        self.stack.push(self.stack.top)
 
     def DUP_TOP_TWO(self, instr: Instruction):
         for ref in self.stack.peek(2):

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -514,6 +514,9 @@ class OpcodeExecutorBase:
         ] | None = None  # store kwnames for Python 3.11+
         self._prepare_virtual_env()
 
+    def __del__(self):
+        del self.stack
+
     def print_sir(self):
         """
         Prints the Static Instruction Representation (SIR) in the executor.

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -514,9 +514,6 @@ class OpcodeExecutorBase:
         ] | None = None  # store kwnames for Python 3.11+
         self._prepare_virtual_env()
 
-    def __del__(self):
-        del self.stack
-
     def print_sir(self):
         """
         Prints the Static Instruction Representation (SIR) in the executor.

--- a/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -263,9 +263,9 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
 
     def RETURN_VALUE(self, instr: Instruction):
         assert (
-            len(self._stack) == 1
-        ), f"Stack must have one element, but get {len(self._stack)} elements."
-        self.return_value = self.pop()
+            len(self.stack) == 1
+        ), f"Stack must have one element, but get {len(self.stack)} elements."
+        self.return_value = self.stack.pop()
         return Stop()
 
     def _break_graph_in_jump(self, result, instr: Instruction):
@@ -289,7 +289,7 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
         raise BreakGraphError("_create_resume_fn.")
 
     def FOR_ITER(self, instr: Instruction):
-        iterator = self.peek()
+        iterator = self.stack.peek()
         assert isinstance(iterator, IterVariable)
 
         self._graph.add_global_guarded_variable(iterator)
@@ -300,9 +300,9 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
             (SequenceIterVariable, DictIterVariable, EnumerateVariable),
         ):
             try:
-                self.push(iterator.next())
+                self.stack.push(iterator.next())
             except StopIteration:
-                self.pop()
+                self.stack.pop()
                 assert isinstance(instr.jump_to, Instruction)
                 self._lasti = self.indexof(instr.jump_to)
 

--- a/sot/opcode_translator/executor/opcode_inline_executor.py
+++ b/sot/opcode_translator/executor/opcode_inline_executor.py
@@ -289,7 +289,7 @@ class OpcodeInlineExecutor(OpcodeExecutorBase):
         raise BreakGraphError("_create_resume_fn.")
 
     def FOR_ITER(self, instr: Instruction):
-        iterator = self.stack.peek()
+        iterator = self.stack.top
         assert isinstance(iterator, IterVariable)
 
         self._graph.add_global_guarded_variable(iterator)

--- a/sot/opcode_translator/executor/variable_stack.py
+++ b/sot/opcode_translator/executor/variable_stack.py
@@ -107,7 +107,7 @@ class VariableStack(Generic[StackDataT]):
         )
 
     def copy(self):
-        return VariableStack(self._data.copy())
+        return VariableStack(self._data.copy(), validator=self.validate_value)
 
     def push(self, val: StackDataT):
         """

--- a/sot/opcode_translator/executor/variable_stack.py
+++ b/sot/opcode_translator/executor/variable_stack.py
@@ -72,12 +72,12 @@ class VariableStack(Generic[StackDataT]):
         ) -> StackDataT | list[StackDataT]:
             if isinstance(index, int):
                 assert index >= 0
-                return self.stack._data[-index]
+                return self._data[-index]
             if isinstance(index, slice):
                 assert index.start is None
                 assert index.step is None
                 assert index.stop > 0
-                return self.stack._data[-index.stop :]
+                return self._data[-index.stop :]
             raise NotImplementedError(f"index type {type(index)} not supported")
 
         def __setitem__(self, index: int, value: Any):
@@ -98,12 +98,13 @@ class VariableStack(Generic[StackDataT]):
         *,
         validator: ValidateValueFunc | None = None,
     ):
-        if validator is None:
-            validate_value = lambda _: None
-        else:
-            validate_value = validator
+        self.validate_value = (
+            (lambda _: None) if validator is None else validator
+        )
         self._data = data or []
-        self._peeker = VariableStack.VariablePeeker(self._data, validate_value)
+        self._peeker = VariableStack.VariablePeeker(
+            self._data, self.validate_value
+        )
 
     def copy(self):
         return VariableStack(self._data.copy())

--- a/sot/opcode_translator/executor/variable_stack.py
+++ b/sot/opcode_translator/executor/variable_stack.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, overload
+
+if TYPE_CHECKING:
+    ValidateValueFunc = Callable[[Any], None]
+
+
+StackDataT = TypeVar("StackDataT")
+
+
+class VariableStack(Generic[StackDataT]):
+    """
+    A stack class for storing variables.
+
+    Examples:
+        >>> var1, var2, var3, var4 = (ConstantVariable.wrap_literal(i, None) for i in range(4))
+        >>> stack = VariableStack()
+        >>> stack.push(var1)  # stack.insert(0, var1)
+        >>> stack.push(var3)
+        >>> stack.insert(1, var2)
+        >>> stack
+        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
+        >>> stack.pop()
+        ConstantVariable(2, 2, object_6)
+        >>> stack.pop_n(2)
+        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5)]
+        >>> stack.push(var1)
+        >>> stack.push(var2)
+        >>> stack.push(var3)
+        >>> stack
+        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
+        >>> stack.top
+        ConstantVariable(2, 2, object_6)
+        >>> stack.peek[1]
+        ConstantVariable(2, 2, object_6)
+        >>> stack.peek[:1]
+        [ConstantVariable(2, 2, object_6)]
+        >>> stack.peek[:2]
+        [ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
+        >>> stack.peek[1] = var4
+        >>> stack
+        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(3, 3, object_7)]
+
+    """
+
+    class VariablePeeker:
+        @overload
+        def __getitem__(self, index: int) -> StackDataT:
+            ...
+
+        @overload
+        def __getitem__(self, index: slice) -> list[StackDataT]:
+            ...
+
+        @overload
+        def __call__(self, index: int = 1) -> StackDataT:
+            ...
+
+        @overload
+        def __call__(self, index: slice) -> list[StackDataT]:
+            ...
+
+        def __init__(self, stack: VariableStack):
+            self.stack = stack
+
+        def __getitem__(
+            self, index: int | slice
+        ) -> StackDataT | list[StackDataT]:
+            if isinstance(index, int):
+                assert index >= 0
+                return self.stack._data[-index]
+            if isinstance(index, slice):
+                assert index.start is None
+                assert index.step is None
+                assert index.stop > 0
+                return self.stack._data[-index.stop :]
+            raise NotImplementedError(f"index type {type(index)} not supported")
+
+        def __setitem__(self, index: int, value):
+            assert isinstance(
+                index, int
+            ), f"index type {type(index)} not supported"
+            self.stack.validate_value(value)
+            self.stack._data[-index] = value
+
+        def __call__(
+            self, index: int | slice = 1
+        ) -> StackDataT | list[StackDataT]:
+            return self[index]
+
+    def __init__(
+        self,
+        data: list[StackDataT] | None = None,
+        *,
+        validator: ValidateValueFunc | None = None,
+    ):
+        self._data = data or []
+        self._peeker = VariableStack.VariablePeeker(self)
+        if validator is None:
+            self.validate_value = lambda _: None
+        else:
+            self.validate_value = validator
+
+    def copy(self):
+        return VariableStack(self._data.copy())
+
+    def push(self, val: StackDataT):
+        """
+        Pushes a variable onto the stack.
+
+        Args:
+            val: The variable to be pushed.
+
+        """
+        self.validate_value(val)
+        self._data.append(val)
+
+    def insert(self, index: int, val: StackDataT):
+        """
+        Inserts a variable onto the stack.
+
+        Args:
+            index: The index at which the variable is to be inserted, the top of the stack is at index 0.
+            val: The variable to be inserted.
+
+        """
+        assert index >= 0
+        self.validate_value(val)
+        self._data.insert(len(self) - index, val)
+
+    def pop(self) -> StackDataT:
+        """
+        Pops the top value from the stack.
+
+        Returns:
+            The popped value.
+
+        """
+        return self._data.pop()
+
+    def pop_n(self, n: int) -> list[StackDataT]:
+        """
+        Pops the top n values from the stack.
+
+        Args:
+            n: The number of values to pop.
+
+        Returns:
+            A list of the popped values.
+
+        """
+        assert (
+            len(self) >= n >= 0
+        ), f"n should be in [0, {len(self)}], but get {n}"
+        if n == 0:
+            return []
+        retval = self._data[-n:]
+        self._data[-n:] = []
+        return retval
+
+    @property
+    def peek(self):
+        return self._peeker
+
+    @property
+    def top(self):
+        return self.peek[1]
+
+    @top.setter
+    def top(self, value):
+        self.peek[1] = value
+
+    def __len__(self):
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        return str(self._data)

--- a/sot/opcode_translator/executor/variable_stack.py
+++ b/sot/opcode_translator/executor/variable_stack.py
@@ -14,33 +14,33 @@ class VariableStack(Generic[StackDataT]):
     A stack class for storing variables.
 
     Examples:
-        >>> var1, var2, var3, var4 = (ConstantVariable.wrap_literal(i, None) for i in range(4))
+        >>> var1, var2, var3, var4 = range(1, 5)
         >>> stack = VariableStack()
-        >>> stack.push(var1)  # stack.insert(0, var1)
+        >>> stack.push(var1)
         >>> stack.push(var3)
         >>> stack.insert(1, var2)
         >>> stack
-        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
+        [1, 2, 3]
         >>> stack.pop()
-        ConstantVariable(2, 2, object_6)
+        3
         >>> stack.pop_n(2)
-        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5)]
+        [1, 2]
         >>> stack.push(var1)
         >>> stack.push(var2)
         >>> stack.push(var3)
         >>> stack
-        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
+        [1, 2, 3]
         >>> stack.top
-        ConstantVariable(2, 2, object_6)
+        3
         >>> stack.peek[1]
-        ConstantVariable(2, 2, object_6)
+        3
         >>> stack.peek[:1]
-        [ConstantVariable(2, 2, object_6)]
+        [3]
         >>> stack.peek[:2]
-        [ConstantVariable(1, 1, object_5), ConstantVariable(2, 2, object_6)]
+        [2, 3]
         >>> stack.peek[1] = var4
         >>> stack
-        [ConstantVariable(0, 0, object_4), ConstantVariable(1, 1, object_5), ConstantVariable(3, 3, object_7)]
+        [1, 2, 4]
 
     """
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -15,9 +15,13 @@ class TestVariableStack(unittest.TestCase):
         self.assertEqual(stack.peek(), 3)
         self.assertEqual(stack.top, 3)
         self.assertEqual(stack.peek(1), 3)
-        self.assertEqual(stack.peek[1], 3)
-        self.assertEqual(stack.peek[:1], [3])
-        self.assertEqual(stack.peek[:2], [2, 3])
+        stack.peek[1] = 4
+        stack.peek[2] = 3
+        self.assertEqual(stack.peek[1], 4)
+        self.assertEqual(stack.peek[:1], [4])
+        self.assertEqual(stack.peek[:2], [3, 4])
+        stack.top = 5
+        self.assertEqual(stack.peek[:2], [3, 5])
 
     def test_push_pop(self):
         stack = VariableStack()

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -8,7 +8,7 @@ class TestVariableStack(unittest.TestCase):
         stack = VariableStack([1, 2, 3])
         self.assertEqual(str(stack), "[1, 2, 3]")
         self.assertEqual(len(stack), 3)
-        self.assertEqual(stack.copy(), stack)
+        self.assertEqual(str(stack.copy()), str(stack))
 
     def test_peek(self):
         stack = VariableStack([1, 2, 3])
@@ -23,9 +23,6 @@ class TestVariableStack(unittest.TestCase):
         stack = VariableStack()
         stack.push(1)
         stack.push(2)
-        self.assertEqual(stack.peek(), 2)
-        self.assertEqual(stack.peek(1), 1)
-        self.assertEqual(stack.peek(2), 2)
         self.assertEqual(stack.pop(), 2)
         self.assertEqual(stack.pop(), 1)
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,0 +1,39 @@
+import unittest
+
+from sot.opcode_translator.executor.variable_stack import VariableStack
+
+
+class TestVariableStack(unittest.TestCase):
+    def test_basic(self):
+        stack = VariableStack([1, 2, 3])
+        self.assertEqual(str(stack), "[1, 2, 3]")
+        self.assertEqual(len(stack), 3)
+        self.assertEqual(stack.copy(), stack)
+
+    def test_peek(self):
+        stack = VariableStack([1, 2, 3])
+        self.assertEqual(stack.peek(), 3)
+        self.assertEqual(stack.top, 3)
+        self.assertEqual(stack.peek(1), 2)
+        self.assertEqual(stack.peek[1], 2)
+        self.assertEqual(stack.peek[:1], [3])
+        self.assertEqual(stack.peek[:2], [2, 3])
+
+    def test_push_pop(self):
+        stack = VariableStack()
+        stack.push(1)
+        stack.push(2)
+        self.assertEqual(stack.peek(), 2)
+        self.assertEqual(stack.peek(1), 1)
+        self.assertEqual(stack.peek(2), 2)
+        self.assertEqual(stack.pop(), 2)
+        self.assertEqual(stack.pop(), 1)
+
+    def test_pop_n(self):
+        stack = VariableStack([1, 2, 3, 4])
+        self.assertEqual(stack.pop_n(2), [3, 4])
+        self.assertEqual(stack.pop_n(2), [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -14,8 +14,8 @@ class TestVariableStack(unittest.TestCase):
         stack = VariableStack([1, 2, 3])
         self.assertEqual(stack.peek(), 3)
         self.assertEqual(stack.top, 3)
-        self.assertEqual(stack.peek(1), 2)
-        self.assertEqual(stack.peek[1], 2)
+        self.assertEqual(stack.peek(1), 3)
+        self.assertEqual(stack.peek[1], 3)
         self.assertEqual(stack.peek[:1], [3])
         self.assertEqual(stack.peek[:2], [2, 3])
 


### PR DESCRIPTION
为了方便python3.11的部分字节码开发，实现了VariableStack，覆盖了大部分可能用到的情况