### PR TITLE
rename `VariableBase.proxy` to `VariableBase.attr_proxy`

### DIFF
--- a/sot/opcode_translator/executor/variables/base.py
+++ b/sot/opcode_translator/executor/variables/base.py
@@ -406,12 +406,12 @@ class VariableBase:
         pass
 
     @cached_property
-    def proxy(self):
+    def attr_proxy(self):
         return self.graph.side_effects.get_proxy(
-            MutableDictLikeData, self.get_py_value(), self.proxy_getter
+            MutableDictLikeData, self.get_py_value(), self.attr_proxy_getter
         )
 
-    def proxy_getter(self, proxy: MutableDictLikeData, name: str):
+    def attr_proxy_getter(self, proxy: MutableDictLikeData, name: str):
         if not hasattr(proxy.original_data, name):  # can't true.
             return MutableDictLikeData.Empty()
 
@@ -468,7 +468,7 @@ class VariableBase:
             )
 
     def getattr(self, name: str, default=None):
-        result = self.proxy.get(name)
+        result = self.attr_proxy.get(name)
         if isinstance(result, MutableDictLikeData.Empty):
             if default is not None:
                 assert isinstance(default, VariableBase)

--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -564,9 +564,9 @@ class SliceVariable(VariableBase):
         pass
 
     @cached_property
-    def proxy(self):
+    def attr_proxy(self):
         return self.graph.side_effects.get_proxy(
-            MutableDictLikeData, self.value, self.proxy_getter
+            MutableDictLikeData, self.value, self.attr_proxy_getter
         )
 
     @property

--- a/sot/opcode_translator/executor/variables/callable.py
+++ b/sot/opcode_translator/executor/variables/callable.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import inspect
 import types
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable
 
 import paddle
@@ -30,7 +29,6 @@ from ..guard import (
     object_equal_stringify_guard,
     union_free_vars,
 )
-from ..mutable_data import MutableDictLikeData
 from ..tracker import DanglingTracker, DummyTracker, GetAttrTracker, Tracker
 from .base import VariableBase, VariableFactory
 from .basic import ConstantVariable, PrintStmtVariable
@@ -361,12 +359,6 @@ class LayerVariable(CallableVariable):
     ):
         super().__init__(graph, tracker)
         self.value = layer
-
-    @cached_property
-    def attr_proxy(self):
-        return self.graph.side_effects.get_proxy(
-            MutableDictLikeData, self.get_py_value(), self.attr_proxy_getter
-        )
 
     def get_py_value(self, allow_tensor=False):
         return self.value

--- a/sot/opcode_translator/executor/variables/callable.py
+++ b/sot/opcode_translator/executor/variables/callable.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import types
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable
 
 import paddle
@@ -360,8 +361,11 @@ class LayerVariable(CallableVariable):
     ):
         super().__init__(graph, tracker)
         self.value = layer
-        self.proxy = self.graph.side_effects.get_proxy(
-            MutableDictLikeData, self.get_py_value(), self.proxy_getter
+
+    @cached_property
+    def attr_proxy(self):
+        return self.graph.side_effects.get_proxy(
+            MutableDictLikeData, self.get_py_value(), self.attr_proxy_getter
         )
 
     def get_py_value(self, allow_tensor=False):


### PR DESCRIPTION
VariableBase 上的也叫 proxy 是有风险的，一旦未来有一个 Variable 既使用默认 `__getattr__` 又自己实现了一个 `proxy`，就可能冲突

而且其只针对属性，因此改名为 `attr_proxy`