### PR TITLE
[Compat][3.11] enable `test_analysis_inputs` and fix `calc_offset_from_bytecode_offset`

### DIFF
--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -82,7 +82,9 @@ def get_instructions(code: types.CodeType) -> list[Instruction]:
     instrs = list(map(convert_instruction, dis.get_instructions(code)))
     for instr in instrs:
         if instr.opname in ALL_JUMP:
-            origin_jump_target = calc_offset_from_bytecode_offset(instr.argval)
+            origin_jump_target = calc_offset_from_bytecode_offset(
+                instr.argval, instrs
+            )
             jump_offset = origin_jump_target
 
             while instrs[jump_offset].opname == "EXTENDED_ARG":
@@ -259,7 +261,10 @@ def modify_vars(instructions, code_options):
             instrs.arg = co_varnames.index(instrs.argval)
 
 
-def calc_offset_from_bytecode_offset(bytecode_offset: int) -> int:
+def calc_offset_from_bytecode_offset(
+    bytecode_offset: int,
+    instructions: list[dis.Instruction] | list[Instruction],
+) -> int:
     """
     Calculate the index from bytecode offset, because it have 2 bytes per instruction (for Python <= 3.10).
 
@@ -270,7 +275,9 @@ def calc_offset_from_bytecode_offset(bytecode_offset: int) -> int:
         int: The index of the instruction in the instruction list.
     """
 
-    # TODO: Change this for Python 3.11+.
+    if sys.version_info >= (3, 11):
+        instruction_offsets = [x.offset for x in instructions]
+        return instruction_offsets.index(bytecode_offset)
     return bytecode_offset // 2
 
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -22,7 +22,6 @@ py311_skiped_tests=(
     ./test_18_tensor_method.py
     ./test_19_closure.py
     ./test_21_global.py
-    ./test_analysis_inputs.py
     ./test_break_graph.py
     ./test_builtin_dispatch.py
     ./test_call_object.py

--- a/tests/test_analysis_inputs.py
+++ b/tests/test_analysis_inputs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import sys
 import unittest
 
 import paddle
@@ -18,7 +19,9 @@ def assert_inputs_equals(instruction_offset: int, expected_inputs: set[str]):
     assert test_frame is not None
 
     instructions = get_instructions(test_frame.f_code)
-    current_instr_idx = calc_offset_from_bytecode_offset(test_frame.f_lasti)
+    current_instr_idx = calc_offset_from_bytecode_offset(
+        test_frame.f_lasti + 2, instructions
+    )
     actual_inputs = analysis_inputs(
         instructions, current_instr_idx + instruction_offset
     )
@@ -127,10 +130,13 @@ def case8(x):
     return x
 
 
+case9_offset = -9 if sys.version_info >= (3, 11) else -7
+
+
 def case9(x):
     x = breakgraph_api(x)
     assert_inputs_equals(
-        -6, set()
+        case9_offset, set()
     )  # analysis when call breakgraph api (CALL_FUNCTION)
     for i in range(10):
         x += 1


### PR DESCRIPTION
适配 Python 3.11 对字节码结构的更改

Python 3.11 每个字节码不一定占据 2 bytes 了，部分字节码包含了 inline cache，使其占据 >= 2 bytes，因此原来的 `calc_offset_from_bytecode_offset` 逻辑直接 `offset // 2` 是有问题的

修复该问题的同时启用了 `test_analysis_inputs` 单测

关于字节码结构更改的核心原理，可以参考新写的博客 [Python 3.11 核心加速原理——指令特化](https://nyakku.moe/posts/2023/08/27/python311-instruction-specializing.html)