### PR TITLE
[Compat][3.11] enable `test_call_object` and `test_dup_top`

### DIFF
--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -24,9 +24,7 @@ py311_skiped_tests=(
     ./test_21_global.py
     ./test_break_graph.py
     ./test_builtin_dispatch.py
-    ./test_call_object.py
     ./test_constant_graph.py
-    ./test_dup_top.py
     ./test_enumerate.py
     ./test_exception.py
     ./test_execution_base.py

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -9,7 +9,6 @@ failed_tests=()
 
 py311_skiped_tests=(
     # ./test_01_basic.py            There are some case need to be fixed
-    # ./test_03_tuple.py            There are some case need to be fixed
     # ./test_04_list.py             There are some case need to be fixed
     # ./test_05_dict.py             There are some case need to be fixed
     ./test_10_build_unpack.py

--- a/tests/test_03_tuple.py
+++ b/tests/test_03_tuple.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import sys
 import unittest
 
 from test_case_base import TestCaseBase
@@ -62,9 +61,6 @@ class TestBuildTuple(TestCaseBase):
         )
 
 
-@unittest.skipIf(
-    sys.version_info >= (3, 11), "Python 3.11+ is not supported yet."
-)
 class TestTupleMethods(TestCaseBase):
     def test_tuple_methods_int(self):
         self.assert_results(tuple_count_int, 1, paddle.to_tensor(2))

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -218,15 +218,18 @@ class TestListBasic(TestCaseBase):
         )
 
 
-@unittest.skipIf(
-    sys.version_info >= (3, 11), "Python 3.11+ is not supported yet."
-)
 class TestListMethods(TestCaseBase):
+    @unittest.skipIf(
+        sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
+    )
     def test_list_setitem(self):
         self.assert_results_with_side_effects(
             list_setitem_tensor, 1, paddle.to_tensor(2)
         )
 
+    @unittest.skipIf(
+        sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
+    )
     def test_list_count_and_index(self):
         self.assert_results(list_count_int, 1, paddle.to_tensor(2))
         self.assert_results(list_index_int, 1, paddle.to_tensor(2))

--- a/tests/test_05_dict.py
+++ b/tests/test_05_dict.py
@@ -175,9 +175,6 @@ class TestBuildDict(TestCaseBase):
         self.assert_results(build_const_key_map, 1, paddle.to_tensor(2))
 
 
-@unittest.skipIf(
-    sys.version_info >= (3, 11), "Python 3.11+ is not supported yet."
-)
 class TestDictMethods(TestCaseBase):
     def test_dict_get_item(self):
         self.assert_results(dict_get_item, 1, paddle.to_tensor(2))
@@ -228,6 +225,10 @@ class TestDictMethods(TestCaseBase):
             dict_popitem, 1, paddle.to_tensor(2)
         )
 
+    @unittest.skipIf(
+        sys.version_info >= (3, 11),
+        "dict_construct_from_comprehension Python 3.11+ has some issues",
+    )
     def test_construct(self):
         self.assert_results(dict_construct_from_dict)
         self.assert_results(dict_construct_from_list)


### PR DESCRIPTION
在 Python 3.11 启用 `test_call_object` 和 `test_dup_top`