### PR TITLE
[Compat][3.11] enable `test_side_effects.py` and fix side effect codegen

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -86,7 +86,7 @@ CustomCode = collections.namedtuple(
 )
 
 
-GuardedFunction = Tuple[types.CodeType, Guard]
+GuardedFunction = Tuple[CustomCode, Guard]
 GuardedFunctions = List[GuardedFunction]
 CacheGetter = Callable[
     [types.FrameType, GuardedFunctions], Optional[CustomCode]
@@ -279,7 +279,7 @@ class InstructionTranslatorCache:
         return self.lookup(**kwargs), (custom_new_code, guard_fn)
 
 
-def start_translate(frame: types.FrameType, **kwargs) -> GuardedFunction | None:
+def start_translate(frame: types.FrameType, **kwargs) -> GuardedFunction:
     """
     Starts the translation process for the given frame and returns the translated code object and its guard function, or None if translation fails.
 

--- a/sot/opcode_translator/instruction_utils/opcode_info.py
+++ b/sot/opcode_translator/instruction_utils/opcode_info.py
@@ -1,3 +1,5 @@
+import sys
+
 import opcode
 
 REL_JUMP = {opcode.opname[x] for x in opcode.hasjrel}
@@ -6,6 +8,8 @@ HAS_LOCAL = {opcode.opname[x] for x in opcode.haslocal}
 HAS_FREE = {opcode.opname[x] for x in opcode.hasfree}
 ALL_JUMP = REL_JUMP | ABS_JUMP
 UNCONDITIONAL_JUMP = {"JUMP_ABSOLUTE", "JUMP_FORWARD"}
+if sys.version_info >= (3, 11):
+    UNCONDITIONAL_JUMP.add("JUMP_BACKWARD")
 
 
 # Cache for some opcodes, it's for Python 3.11+

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -33,7 +33,6 @@ py311_skiped_tests=(
     ./test_range.py
     ./test_resnet.py
     ./test_resnet50_backward.py
-    ./test_side_effects.py
     ./test_sir_rollback.py
     ./test_str_format.py
     ./test_tensor_dtype_in_guard.py

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -33,6 +33,7 @@ py311_skiped_tests=(
     ./test_range.py
     ./test_resnet.py
     ./test_resnet50_backward.py
+    # ./test_side_effects.py        There are some case need to be fixed
     ./test_sir_rollback.py
     ./test_str_format.py
     ./test_tensor_dtype_in_guard.py

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import unittest
 
 from test_case_base import TestCaseBase, strict_mode_guard
@@ -233,6 +234,9 @@ class TestListSideEffect(TestCaseBase):
             list_reverse, [-1, 2, -3, 4, -5, 6, -7, 8, -9]
         )
 
+    @unittest.skipIf(
+        sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
+    )
     def test_slice_in_for_loop(self):
         x = 2
         with strict_mode_guard(0):
@@ -242,6 +246,9 @@ class TestListSideEffect(TestCaseBase):
         self.assert_results_with_side_effects(list_nested, [1, 2, 3])
 
 
+@unittest.skipIf(
+    sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
+)
 class TestSliceAfterChange(TestCaseBase):
     def test_slice_list_after_change(self):
         self.assert_results_with_side_effects(


### PR DESCRIPTION
适配 side effects codegen 中的 `gen_call_method`，启用该单测，并稍微优化调整部分现有逻辑

部分需要子图打断的先行 skip

相关任务：任务 11

单测状态变化：

- `test_side_effects.py` ❌ -> 🚧