### PR TITLE
[opcode][3.11] support MAKE_FUNCTION in py311

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -1265,8 +1265,17 @@ class OpcodeExecutorBase:
         )
 
     def MAKE_FUNCTION(self, instr: Instruction):
-        fn_name = self.stack.pop()
+        if sys.version_info < (3, 11):
+            fn_name = self.stack.pop()
         codeobj = self.stack.pop()
+        if sys.version_info >= (3, 11):
+            # MAKE_FUNCTION behavior actually changed in 3.11, see
+            # https://github.com/python/cpython/pull/93189/
+            assert hasattr(codeobj.value, "co_qualname")
+            fn_name = ConstantVariable(
+                codeobj.value.co_qualname, self._graph, DummyTracker([codeobj])
+            )
+
         global_dict = self._globals.get_value()
 
         related_list = [fn_name, codeobj]

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -15,7 +15,6 @@ py311_skiped_tests=(
     ./test_10_build_unpack.py
     ./test_11_jumps.py
     ./test_12_for_loop.py
-    ./test_13_make_function.py
     ./test_14_operators.py
     ./test_15_slice.py
     ./test_17_paddle_layer.py

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -227,9 +227,6 @@ class TestListMethods(TestCaseBase):
             list_setitem_tensor, 1, paddle.to_tensor(2)
         )
 
-    @unittest.skipIf(
-        sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
-    )
     def test_list_count_and_index(self):
         self.assert_results(list_count_int, 1, paddle.to_tensor(2))
         self.assert_results(list_index_int, 1, paddle.to_tensor(2))


### PR DESCRIPTION
支持`python3.11`的`MAKE_FUNCTION`

`python3.11`:
```bash
 13           2 LOAD_CONST               8 ((2, 3, 4))
              4 LOAD_CONST               4 (<code object fn at 0x109149960, file "/Users/gouzi/Documents/git/paddle-symbolic-trace/tests/test_13_make_function.py", line 13>)
              6 MAKE_FUNCTION            1 (defaults)
              8 STORE_FAST               1 (fn)
```

`python3.8`:
```bash
 13           0 LOAD_CONST               9 ((2, 3, 4))
              2 LOAD_CONST               4 (<code object fn at 0x10e0126b0, file "/Users/gouzi/Downloads/PaddleSOT/tests/test_13_make_function.py", line 13>)
              4 LOAD_CONST               5 ('make_fn.<locals>.fn')
              6 MAKE_FUNCTION            1 (defaults)
              8 STORE_FAST               1 (fn)
```

相关任务：任务 5

单测状态变化：

- `test_13_make_function.py` ❌ -> ✅