### PR TITLE
[Compat][3.11] support call breakgraph

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -1879,11 +1879,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
             self._graph.pycode_gen.gen_load_object(
                 resume_fn, resume_fn.__code__.co_name
             )
-            if sys.version_info >= (3, 11):
-                # NOTE(zrr1999): In Python 3.11+, NULL + resume_fn should be shifted together.
-                self._graph.pycode_gen.gen_shift_n(2, stack_size + 2)
-            else:
-                self._graph.pycode_gen.gen_shift_n(1, stack_size + 1)
+            # NOTE(zrr1999): We need to shift the resume_fn under its arguments.
+            # In Python 3.11+, NULL + resume_fn should be shifted together.
+            shift_n = 2 if sys.version_info >= (3, 11) else 1
+            self._graph.pycode_gen.gen_shift_n(shift_n, stack_size + shift_n)
             for name in resume_input_name:
                 var_loader.load(self.get_var(name))
             self._graph.pycode_gen.gen_call_function(

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -1823,7 +1823,6 @@ class OpcodeExecutor(OpcodeExecutorBase):
             push_n: The number of elements to be pushed onto the stack.
 
         """
-        assert instr.arg is not None
         index = self.indexof(instr)
         self.stack = origin_stack
 
@@ -1855,6 +1854,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
 
         # gen graph break call fn opcode
         if sys.version_info >= (3, 11) and instr.opname == "CALL":
+            assert instr.arg is not None
             stack_effect = -instr.arg - 1
         else:
             stack_effect = dis.stack_effect(instr.opcode, instr.arg)

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -1884,8 +1884,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 resume_fn, resume_fn.__code__.co_name
             )
             if sys.version_info >= (3, 11):
-                self._graph.pycode_gen.gen_rot_n(stack_size + 2)
-                self._graph.pycode_gen.gen_rot_n(stack_size + 2)
+                self._graph.pycode_gen.gen_shift_n(2, stack_size + 2)
             else:
                 self._graph.pycode_gen.gen_rot_n(stack_size + 1)
             for name in resume_input_name:

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -1870,11 +1870,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 var_loader.load(stack_arg)
 
         # gen call resume fn opcode
-        if sys.version_info >= (3, 11) and instr.opname == "CALL":
-            assert instr.arg is not None
-            self._graph.pycode_gen.gen_call_function(instr.arg)
-        else:
-            self._graph.pycode_gen.add_pure_instructions([instr])
+        self._graph.pycode_gen.add_pure_instructions([instr])
         self.stack.pop_n(pop_n)
         stack_size = len(self.stack) + push_n
 
@@ -1884,9 +1880,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 resume_fn, resume_fn.__code__.co_name
             )
             if sys.version_info >= (3, 11):
+                # NOTE(zrr1999): In Python 3.11+, NULL + resume_fn should be shifted together.
                 self._graph.pycode_gen.gen_shift_n(2, stack_size + 2)
             else:
-                self._graph.pycode_gen.gen_rot_n(stack_size + 1)
+                self._graph.pycode_gen.gen_shift_n(1, stack_size + 1)
             for name in resume_input_name:
                 var_loader.load(self.get_var(name))
             self._graph.pycode_gen.gen_call_function(

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -1754,7 +1754,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         ] + inputs_var
         # Collect all the to store variables.
         store_vars = []
-        for stack_arg in self.stack._data:
+        for stack_arg in self.stack:
             store_vars.append(stack_arg)
         for name in inputs_name:
             store_vars.append(self.get_var(name))
@@ -1772,7 +1772,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 if_fn, if_fn.__code__.co_name
             )
             insert_index = len(self._graph.pycode_gen._instructions) - 1
-            for stack_arg in self.stack._data:
+            for stack_arg in self.stack:
                 var_loader.load(stack_arg)
             for name in if_inputs:
                 var_loader.load(self.get_var(name))
@@ -1789,7 +1789,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 else_fn, else_fn.__code__.co_name
             )
             jump_to = self._graph.pycode_gen._instructions[-1]
-            for stack_arg in self.stack._data:
+            for stack_arg in self.stack:
                 var_loader.load(stack_arg)
             for name in else_inputs:
                 var_loader.load(self.get_var(name))
@@ -1823,13 +1823,14 @@ class OpcodeExecutor(OpcodeExecutorBase):
             push_n: The number of elements to be pushed onto the stack.
 
         """
+        assert instr.arg is not None
         index = self.indexof(instr)
         self.stack = origin_stack
 
         # gen call static fn opcode
         ret_vars = [
             arg
-            for arg in self.stack._data
+            for arg in self.stack
             if isinstance(arg, (TensorVariable, ContainerVariable))
         ]
         resume_input_name = analysis_inputs(self._instructions, index + 1)
@@ -1841,7 +1842,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
 
         # Collect all the to store variables.
         store_vars = []
-        for stack_arg in self.stack._data:
+        for stack_arg in self.stack:
             store_vars.append(stack_arg)
         for name in resume_input_name:
             store_vars.append(self.get_var(name))
@@ -1853,30 +1854,43 @@ class OpcodeExecutor(OpcodeExecutorBase):
             self._graph.pycode_gen.gen_pop_top()
 
         # gen graph break call fn opcode
-        stack_effect = dis.stack_effect(instr.opcode, instr.arg)
+        if sys.version_info >= (3, 11) and instr.opname == "CALL":
+            stack_effect = -instr.arg - 1
+        else:
+            stack_effect = dis.stack_effect(instr.opcode, instr.arg)
         pop_n = push_n - stack_effect
-        for i, stack_arg in enumerate(self.stack._data):
+
+        for i, stack_arg in enumerate(self.stack):
             # Avoid passing NULL as a parameter to the resume function
             if (
                 isinstance(stack_arg, NullVariable)
                 and i < len(self.stack) - pop_n
             ):
                 self._graph.pycode_gen.gen_load_object(
-                    NullVariable(), f'dummy_var{i}'
+                    NullVariable(), f'dummy_var{i}', push_null=False
                 )
             else:
                 var_loader.load(stack_arg)
-        self._graph.pycode_gen.add_pure_instructions([instr])
 
         # gen call resume fn opcode
+        if sys.version_info >= (3, 11) and instr.opname == "CALL":
+            assert instr.arg is not None
+            self._graph.pycode_gen.gen_call_function(instr.arg)
+        else:
+            self._graph.pycode_gen.add_pure_instructions([instr])
         self.stack.pop_n(pop_n)
         stack_size = len(self.stack) + push_n
+
         resume_fn, _ = self._create_resume_fn(index + 1, stack_size)
         if resume_fn:
             self._graph.pycode_gen.gen_load_object(
                 resume_fn, resume_fn.__code__.co_name
             )
-            self._graph.pycode_gen.gen_rot_n(stack_size + 1)
+            if sys.version_info >= (3, 11):
+                self._graph.pycode_gen.gen_rot_n(stack_size + 2)
+                self._graph.pycode_gen.gen_rot_n(stack_size + 2)
+            else:
+                self._graph.pycode_gen.gen_rot_n(stack_size + 1)
             for name in resume_input_name:
                 var_loader.load(self.get_var(name))
             self._graph.pycode_gen.gen_call_function(
@@ -2041,7 +2055,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         ]
         ret_vars = [self.get_var(name) for name in ret_names]
         store_vars = [ret_vars[idx] for idx in range(len(ret_names))]
-        store_vars.extend(iter(self.stack._data))
+        store_vars.extend(iter(self.stack))
         var_loader = self._graph.start_compile_with_name_store(
             ret_vars, store_vars
         )
@@ -2106,7 +2120,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
             after_loop_fn, after_loop_fn.__code__.co_name
         )
 
-        for stack_arg in self.stack._data:
+        for stack_arg in self.stack:
             var_loader.load(stack_arg)
         for name in fn_inputs:
             self._graph.pycode_gen.gen_load(name)

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -825,15 +825,22 @@ class PyCodeGen:
             if s == 1:
                 self.gen_rot_n(n)
             else:
-                raise NotImplementedError("shift_n is not supported")
+                self.gen_rot_n(n)
+                self.gen_shift_n(s - 1, n)
 
         else:  # s < 0
-            if sys.version_info >= (3, 11) and s == -1:
+            if sys.version_info >= (3, 11):
                 # NOTE: s=-1, n=3 [1,2,3,4,5] -> [1,2,4,5,3]
-                for i in range(2, n + 1):
-                    self._add_instr("SWAP", arg=i)
+                if s == -1:
+                    for i in range(2, n + 1):
+                        self._add_instr("SWAP", arg=i)
+                else:
+                    self.gen_shift_n(-1, n)
+                    self.gen_shift_n(s + 1, n)
             else:
-                raise NotImplementedError("shift_n is not supported")
+                raise NotImplementedError(
+                    "shift_n is not supported before python3.11"
+                )
 
     def gen_swap(self, n):
         if sys.version_info >= (3, 11):

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -816,6 +816,25 @@ class PyCodeGen:
                 self._add_instr("CALL_FUNCTION_EX", arg=0)
                 self.gen_unpack_sequence(n)
 
+    def gen_shift_n(self, s: int, n: int):
+        if s == 0 or n <= 1:
+            return
+        if s > 0:
+            # NOTE: s=1, n=3 [1,2,3,4,5] -> [1,2,5,3,4]
+            #       s=2, n=3 [1,2,3,4,5] -> [1,2,4,5,3]
+            if s == 1:
+                self.gen_rot_n(n)
+            else:
+                raise NotImplementedError("shift_n is not supported")
+
+        else:  # s < 0
+            if sys.version_info >= (3, 11) and s == -1:
+                # NOTE: s=-1, n=3 [1,2,3,4,5] -> [1,2,4,5,3]
+                for i in range(2, n + 1):
+                    self._add_instr("SWAP", arg=i)
+            else:
+                raise NotImplementedError("shift_n is not supported")
+
     def gen_swap(self, n):
         if sys.version_info >= (3, 11):
             self._add_instr("SWAP", arg=n)

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -435,7 +435,7 @@ class PyCodeGen:
 
     def gen_resume_fn_at(
         self, index: int, stack_size: int = 0
-    ) -> tuple[None | types.FunctionType, OrderedSet]:
+    ) -> tuple[None | types.FunctionType, OrderedSet[str]]:
         """
         Generates a resume function at the specified index in the instruction list.
 

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -826,6 +826,12 @@ class PyCodeGen:
         """
         if s == 0 or n <= 1:
             return
+
+        # NOTE(zrr1999): right shift s steps is equal to left shift n-s steps
+        if abs(s) > n // 2:
+            new_s = s - n if s > 0 else s + n
+            self.gen_shift_n(new_s, n)
+            return
         if s > 0:
             # NOTE: s=1, n=3 [1,2,3,4,5] -> [1,2,5,3,4]
             #       s=2, n=3 [1,2,3,4,5] -> [1,2,4,5,3]

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import dis
 import sys
 import types
 from typing import TYPE_CHECKING
@@ -25,6 +24,7 @@ from ...utils import (
 )
 from ..instruction_utils import (
     analysis_inputs,
+    calc_stack_effect,
     gen_instr,
     get_instructions,
     instrs_info,
@@ -383,11 +383,11 @@ def stacksize(instructions: list[Instruction]) -> float:
             idx + 1 < len(instructions)
             and instr.opname not in UNCONDITIONAL_JUMP
         ):
-            stack_effect = dis.stack_effect(instr.opcode, instr.arg, jump=False)
+            stack_effect = calc_stack_effect(instr, jump=False)
             update_stacksize(idx, idx + 1, stack_effect)
 
         if instr.opcode in opcode.hasjabs or instr.opcode in opcode.hasjrel:
-            stack_effect = dis.stack_effect(instr.opcode, instr.arg, jump=True)
+            stack_effect = calc_stack_effect(instr, jump=True)
             target_idx = instructions.index(instr.jump_to)
             update_stacksize(idx, target_idx, stack_effect)
 

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -433,7 +433,9 @@ class PyCodeGen:
         )
         return new_code
 
-    def gen_resume_fn_at(self, index: int, stack_size: int = 0):
+    def gen_resume_fn_at(
+        self, index: int, stack_size: int = 0
+    ) -> tuple[None | types.FunctionType, OrderedSet]:
         """
         Generates a resume function at the specified index in the instruction list.
 
@@ -662,7 +664,7 @@ class PyCodeGen:
                 idx |= 1
         self._add_instr("LOAD_GLOBAL", arg=idx, argval=name)
 
-    def gen_load_object(self, obj, obj_name: str):
+    def gen_load_object(self, obj, obj_name: str, push_null: bool = True):
         """
         Generate the bytecode for loading an object.
 
@@ -673,7 +675,7 @@ class PyCodeGen:
 
         if obj_name not in self._f_globals:
             self._f_globals[obj_name] = obj
-        self.gen_load_global(obj_name, push_null=True)
+        self.gen_load_global(obj_name, push_null=push_null)
 
     def gen_load_fast(self, name):
         """
@@ -813,6 +815,12 @@ class PyCodeGen:
                 self.gen_rot_n(2)
                 self._add_instr("CALL_FUNCTION_EX", arg=0)
                 self.gen_unpack_sequence(n)
+
+    def gen_swap(self, n):
+        if sys.version_info >= (3, 11):
+            self._add_instr("SWAP", arg=n)
+        else:
+            raise NotImplementedError("swap is not supported before python3.11")
 
     def gen_return(self):
         self._add_instr("RETURN_VALUE")

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -817,6 +817,13 @@ class PyCodeGen:
                 self.gen_unpack_sequence(n)
 
     def gen_shift_n(self, s: int, n: int):
+        """
+        Generate the bytecode for shifting the stack.
+
+        Args:
+            s (int): Steps to shift.
+            n (int): The number of elements to shift.
+        """
         if s == 0 or n <= 1:
             return
         if s > 0:

--- a/sot/opcode_translator/executor/variable_stack.py
+++ b/sot/opcode_translator/executor/variable_stack.py
@@ -192,6 +192,9 @@ class VariableStack(Generic[StackDataT]):
         assert len(self) > 0, "stack is empty"
         self.peek[1] = value
 
+    def __iter__(self):
+        return iter(self._data)
+
     def __len__(self) -> int:
         return len(self._data)
 

--- a/sot/opcode_translator/instruction_utils/__init__.py
+++ b/sot/opcode_translator/instruction_utils/__init__.py
@@ -1,6 +1,7 @@
 from .instruction_utils import (
     Instruction,
     calc_offset_from_bytecode_offset,
+    calc_stack_effect,
     convert_instruction,
     gen_instr,
     get_instructions,
@@ -22,6 +23,7 @@ __all__ = [
     "analysis_inputs",
     "analysis_used_names_with_space",
     "calc_offset_from_bytecode_offset",
+    "calc_stack_effect",
     "Instruction",
     "convert_instruction",
     "gen_instr",

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -325,3 +325,21 @@ def instrs_info(instrs, mark=None, range=None):
         if idx == mark:
             ret[-1] = "\033[31m" + ret[-1] + "\033[0m"
     return ret
+
+
+def calc_stack_effect(instr: Instruction, jump: bool | None = None) -> int:
+    """
+    Gets the stack effect of the given instruction.
+
+    Args:
+        instr: The instruction.
+
+    Returns:
+        The stack effect of the instruction.
+
+    """
+    if sys.version_info == (3, 11) and instr.opname == "CALL":
+        # NOTE: python3.11 dis.stack_effect will return -1 for CALL, so we need to get the stack effect manually.
+        assert instr.arg is not None
+        return -instr.arg - 1
+    return dis.stack_effect(instr.opcode, instr.arg, jump=jump)

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -338,8 +338,10 @@ def calc_stack_effect(instr: Instruction, *, jump: bool | None = None) -> int:
         The stack effect of the instruction.
 
     """
-    if sys.version_info >= (3, 11) and instr.opname == "CALL":
-        # NOTE: python3.11 dis.stack_effect will return -1 for CALL, so we need to get the stack effect manually.
-        assert instr.arg is not None
-        return -instr.arg - 1
+    if sys.version_info >= (3, 11):
+        if instr.opname == "PRECALL":
+            return 0
+        elif instr.opname == "CALL":
+            assert instr.arg is not None
+            return -instr.arg - 1
     return dis.stack_effect(instr.opcode, instr.arg, jump=jump)

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -342,6 +342,7 @@ def calc_stack_effect(instr: Instruction, *, jump: bool | None = None) -> int:
         if instr.opname == "PRECALL":
             return 0
         elif instr.opname == "CALL":
+            # NOTE: push_n = 1, pop_n = oparg + 2, stack_effect = push_n - pop_n = -oparg-1
             assert instr.arg is not None
             return -instr.arg - 1
     return dis.stack_effect(instr.opcode, instr.arg, jump=jump)

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -329,7 +329,8 @@ def instrs_info(instrs, mark=None, range=None):
 
 def calc_stack_effect(instr: Instruction, *, jump: bool | None = None) -> int:
     """
-    Gets the stack effect of the given instruction.
+    Gets the stack effect of the given instruction. In Python 3.11, the stack effect of `CALL` is -1,
+    refer to https://github.com/python/cpython/blob/3.11/Python/compile.c#L1123-L1124.
 
     Args:
         instr: The instruction.

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -342,7 +342,7 @@ def calc_stack_effect(instr: Instruction, *, jump: bool | None = None) -> int:
         if instr.opname == "PRECALL":
             return 0
         elif instr.opname == "CALL":
-            # NOTE: push_n = 1, pop_n = oparg + 2, stack_effect = push_n - pop_n = -oparg-1
+            # NOTE(zrr1999): push_n = 1, pop_n = oparg + 2, stack_effect = push_n - pop_n = -oparg-1
             assert instr.arg is not None
             return -instr.arg - 1
     return dis.stack_effect(instr.opcode, instr.arg, jump=jump)

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -338,7 +338,7 @@ def calc_stack_effect(instr: Instruction, *, jump: bool | None = None) -> int:
         The stack effect of the instruction.
 
     """
-    if sys.version_info >= (3, 11):
+    if sys.version_info[:2] == (3, 11):
         if instr.opname == "PRECALL":
             return 0
         elif instr.opname == "CALL":

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -327,7 +327,7 @@ def instrs_info(instrs, mark=None, range=None):
     return ret
 
 
-def calc_stack_effect(instr: Instruction, jump: bool | None = None) -> int:
+def calc_stack_effect(instr: Instruction, *, jump: bool | None = None) -> int:
     """
     Gets the stack effect of the given instruction.
 
@@ -338,7 +338,7 @@ def calc_stack_effect(instr: Instruction, jump: bool | None = None) -> int:
         The stack effect of the instruction.
 
     """
-    if sys.version_info == (3, 11) and instr.opname == "CALL":
+    if sys.version_info >= (3, 11) and instr.opname == "CALL":
         # NOTE: python3.11 dis.stack_effect will return -1 for CALL, so we need to get the stack effect manually.
         assert instr.arg is not None
         return -instr.arg - 1

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -9,22 +9,12 @@ echo "IS_PY311:" $IS_PY311
 failed_tests=()
 
 py311_skiped_tests=(
-    # ./test_01_basic.py            There are some case need to be fixed
-    # ./test_04_list.py             There are some case need to be fixed
-    # ./test_05_dict.py             There are some case need to be fixed
-    # ./test_11_jumps.py            There are some case need to be fixed
     ./test_12_for_loop.py
-    # ./test_14_operators.py        There are some case need to be fixed
     ./test_15_slice.py
-    ./test_18_tensor_method.py
     ./test_19_closure.py
     ./test_21_global.py
-    ./test_break_graph.py
-    ./test_builtin_dispatch.py
     ./test_constant_graph.py
     ./test_enumerate.py
-    ./test_exception.py
-    ./test_execution_base.py
     ./test_guard_user_defined_fn.py
     ./test_inplace_api.py
     ./test_range.py
@@ -32,7 +22,6 @@ py311_skiped_tests=(
     ./test_resnet50_backward.py
     # ./test_side_effects.py        There are some case need to be fixed
     ./test_sir_rollback.py
-    ./test_str_format.py
     ./test_tensor_dtype_in_guard.py
 )
 

--- a/tests/test_01_basic.py
+++ b/tests/test_01_basic.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 from test_case_base import TestCaseBase, strict_mode_guard
@@ -20,9 +19,6 @@ def numpy_add(x, y):
     return out
 
 
-@unittest.skipIf(
-    sys.version_info >= (3, 11), "Python 3.11+ is not supported yet."
-)
 class TestNumpyAdd(TestCaseBase):
     @strict_mode_guard(0)
     def test_numpy_add(self):

--- a/tests/test_04_list.py
+++ b/tests/test_04_list.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import sys
 import unittest
 
 from test_case_base import TestCaseBase
@@ -219,9 +218,6 @@ class TestListBasic(TestCaseBase):
 
 
 class TestListMethods(TestCaseBase):
-    @unittest.skipIf(
-        sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
-    )
     def test_list_setitem(self):
         self.assert_results_with_side_effects(
             list_setitem_tensor, 1, paddle.to_tensor(2)

--- a/tests/test_05_dict.py
+++ b/tests/test_05_dict.py
@@ -2,7 +2,6 @@
 # BUILD_MAP (new)
 # BUILD_CONST_KEY_MAP (new)
 
-import sys
 import unittest
 
 from test_case_base import TestCaseBase
@@ -225,10 +224,6 @@ class TestDictMethods(TestCaseBase):
             dict_popitem, 1, paddle.to_tensor(2)
         )
 
-    @unittest.skipIf(
-        sys.version_info >= (3, 11),
-        "dict_construct_from_comprehension Python 3.11+ has some issues",
-    )
     def test_construct(self):
         self.assert_results(dict_construct_from_dict)
         self.assert_results(dict_construct_from_list)

--- a/tests/test_14_operators.py
+++ b/tests/test_14_operators.py
@@ -1,5 +1,4 @@
 import operator
-import sys
 import unittest
 
 from test_case_base import TestCaseBase
@@ -273,10 +272,6 @@ def operator_pos(y: int):
 
 
 class TestExecutor(TestCaseBase):
-    @unittest.skipIf(
-        sys.version_info >= (3, 11),
-        "Python 3.11+ breakbreak occurred in unary_not",
-    )
     def test_simple(self):
         a = paddle.to_tensor(1)
         b = paddle.to_tensor(True)
@@ -319,9 +314,6 @@ class TestExecutor(TestCaseBase):
         self.assert_results(inplace_or, b, g)
         self.assert_results(inplace_xor, b, g)
 
-    @unittest.skipIf(
-        sys.version_info >= (3, 11), "Python 3.11+ breakbreak occurred in truth"
-    )
     def test_operator_simple(self):
         self.assert_results(operator_add, 1, paddle.to_tensor(2))
         self.assert_results(operator_mul, 1, paddle.to_tensor(2))
@@ -338,9 +330,6 @@ class TestExecutor(TestCaseBase):
         self.assert_results(operator_not_in_, 12, [1, 2, 3])
         self.assert_results(operator_not_in_, 12, [1, 2, 3])
 
-    @unittest.skipIf(
-        sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
-    )
     def test_operator_list(self):
         self.assert_results(list_getitem, 1, paddle.to_tensor(2))
         self.assert_results(list_getitem_slice, 1, paddle.to_tensor(2))
@@ -351,9 +340,6 @@ class TestExecutor(TestCaseBase):
         self.assert_results(list_delitem_int, 1, paddle.to_tensor(2))
         self.assert_results(list_delitem_tensor, 1, paddle.to_tensor(2))
 
-    @unittest.skipIf(
-        sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
-    )
     def test_operator_dict(self):
         self.assert_results(dict_getitem_int, 1, paddle.to_tensor(2))
         self.assert_results(dict_getitem_tensor, 1, paddle.to_tensor(2))
@@ -364,9 +350,6 @@ class TestExecutor(TestCaseBase):
         self.assert_results(dict_delitem_int, 1, paddle.to_tensor(2))
         self.assert_results(dict_delitem_tensor, 1, paddle.to_tensor(2))
 
-    @unittest.skipIf(
-        sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
-    )
     def test_operator_tuple(self):
         self.assert_results(tuple_getitem_int, 1, paddle.to_tensor(2))
         self.assert_results(tuple_getitem_tensor, 1, paddle.to_tensor(2))

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -235,7 +235,8 @@ class TestListSideEffect(TestCaseBase):
         )
 
     @unittest.skipIf(
-        sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
+        sys.version_info >= (3, 11),
+        "Python 3.11+ not support for-loop breakgraph",
     )
     def test_slice_in_for_loop(self):
         x = 2
@@ -247,7 +248,7 @@ class TestListSideEffect(TestCaseBase):
 
 
 @unittest.skipIf(
-    sys.version_info >= (3, 11), "Python 3.11+ not support breakgraph"
+    sys.version_info >= (3, 11), "Python 3.11+ not support for-loop breakgraph"
 )
 class TestSliceAfterChange(TestCaseBase):
     def test_slice_list_after_change(self):


### PR DESCRIPTION
本PR改动如下：

1. 实现 calc_stack_effect 函数，因为 dis.stack_effect 在 Python3.11 下对 CALL 字节码的计算不符合逻辑，结果恒为 `-1`，因此实现自定义的calc_stack_effect计算 stack_effect值，也可以为后续其他版本适配起到一定帮助。
2. 实现 VariableStack的iter方法，简化代码。
3. 实现 PyCodeGen 的 gen_shift_n 方法，用于简化字节码生成，目前可以简化 Python3.11 下的两次rot_n操作
4. 为 gen_load_object 添加 push_null参数，使得当obj为NULL时可以保证push_null=False不会多传入NULL
5. 开启部分测试
   - test_01_basic 🚧 -> ✅
   - test_04_list 🚧 -> ✅
   - test_05_dict 🚧 -> ✅
   - test_14_operators 🚧 -> ✅
   - test_18_tensor_method ❌ -> ✅
   - test_break_graph ❌ -> ✅
   - test_builtin_dispatch ❌ -> ✅
   - test_exception ❌ -> ✅
   - test_execution_base ❌ -> ✅
   - test_str_format ❌ -> ✅