### PR TITLE
[Compat][3.11] enable graph break example

### DIFF
--- a/examples/graph_break.py
+++ b/examples/graph_break.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 
 import paddle
@@ -29,7 +27,4 @@ def main():
 
 
 if __name__ == '__main__':
-    if sys.version_info >= (3, 11):
-        print("We don't support graph break in Python 3.11 yet.")
-        sys.exit(0)
     main()

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -1,6 +1,7 @@
 # 遍历目录下的所有 Python 文件
 export PYTHONPATH=$PYTHONPATH:../
 export STRICT_MODE=1
+export MIN_GRAPH_SIZE=-1
 
 for file in ./*.py; do
     # 检查文件是否为 Python 文件

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -314,7 +314,7 @@ def start_translate(frame: types.FrameType, **kwargs) -> GuardedFunction:
 
             # NOTE: If resume fn need fallback, we should replace NullVariable using NULL otherwise will fail to run
             py_codegen = PyCodeGen(frame)
-            new_code = py_codegen.replace_dummy_variable()
+            new_code = py_codegen.replace_null_variable()
             # simulation not complete, not sure whether this code has sir, set disable_eval_frame = False
             return (
                 CustomCode(new_code, False),
@@ -1864,7 +1864,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 and i < len(self.stack) - pop_n
             ):
                 self._graph.pycode_gen.gen_load_object(
-                    NullVariable(), f'dummy_var{i}', push_null=False
+                    NullVariable(), f'null_var_{i}', push_null=False
                 )
             else:
                 var_loader.load(stack_arg)
@@ -1910,7 +1910,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         else:
             # use origin code if sir is too small
             py_codegen = PyCodeGen(self._frame)
-            new_code = py_codegen.replace_dummy_variable()
+            new_code = py_codegen.replace_null_variable()
             return CustomCode(new_code, True), self.guard_fn
 
     def graph_size(self):

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -1909,7 +1909,9 @@ class OpcodeExecutor(OpcodeExecutorBase):
             )
         else:
             # use origin code if sir is too small
-            return CustomCode(self._code, True), self.guard_fn
+            py_codegen = PyCodeGen(self._frame)
+            new_code = py_codegen.replace_dummy_variable()
+            return CustomCode(new_code, True), self.guard_fn
 
     def graph_size(self):
         size = len(self._graph.sir_ctx.TOS.statements)

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -891,7 +891,7 @@ class PyCodeGen:
     def pop_instr(self):
         self._instructions.pop()
 
-    def replace_dummy_variable(self):
+    def replace_null_variable(self):
         """
         Replace any dummy variables in the bytecode.
 
@@ -901,19 +901,19 @@ class PyCodeGen:
         from .variables.basic import NullVariable
 
         instructions = get_instructions(self._origin_code)
-        has_dummy_variable = False
+        has_null_variable = False
         for instr in instructions:
             if (
                 instr.opname == 'LOAD_FAST'
                 and instr.argval in self._frame.f_locals.keys()
                 and isinstance(self._frame.f_locals[instr.argval], NullVariable)
             ):
-                has_dummy_variable = True
+                has_null_variable = True
                 self._frame.f_locals[instr.argval].reconstruct(self)
             else:
                 self.add_pure_instructions([instr])
 
-        if has_dummy_variable:
+        if has_null_variable:
             new_code = self.gen_pycode()
             return new_code
         else:

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -893,7 +893,7 @@ class PyCodeGen:
 
     def replace_null_variable(self):
         """
-        Replace any dummy variables in the bytecode.
+        Replace all NullVariables in the bytecode.
 
         Returns:
             Optional[Tuple[Any, Callable]]: The new code object and its guard function, or None if no dummy variables are found.

--- a/sot/opcode_translator/instruction_utils/opcode_analysis.py
+++ b/sot/opcode_translator/instruction_utils/opcode_analysis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from enum import Enum
 
-from ...utils import OrderedSet
+from ...utils import InnerError, OrderedSet
 from .instruction_utils import Instruction
 from .opcode_info import ALL_JUMP, HAS_FREE, HAS_LOCAL, UNCONDITIONAL_JUMP
 
@@ -112,8 +112,8 @@ def analysis_inputs(
 
 @dataclasses.dataclass
 class SpaceState:
-    reads: dict[str, str]
-    writes: dict[str, str]
+    reads: dict[str, Space]
+    writes: dict[str, Space]
     visited: OrderedSet[int]
 
     def __or__(self, other):
@@ -141,7 +141,9 @@ def get_space(opname: str):
     elif "DEREF" in opname or "CLOSURE" in opname:
         return Space.cells
     elif "NAME" in opname:
-        return Space.any
+        return Space.all
+    else:
+        raise InnerError(f"Unknown space for {opname}")
 
 
 def analysis_used_names_with_space(

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -21,7 +21,6 @@ py311_skiped_tests=(
     ./test_resnet.py
     ./test_resnet50_backward.py
     # ./test_side_effects.py        There are some case need to be fixed
-    ./test_sir_rollback.py
     ./test_tensor_dtype_in_guard.py
 )
 

--- a/tests/run_all_paddle_ci.sh
+++ b/tests/run_all_paddle_ci.sh
@@ -1,6 +1,7 @@
 export STRICT_MODE=0
 export ENABLE_SOT=True
 export ENABLE_FALL_BACK=True
+export MIN_GRAPH_SIZE=-1
 
 PADDLE_TEST_BASE=./Paddle/test/dygraph_to_static
 failed_tests=()


### PR DESCRIPTION
- 确保所有 fallback 的出口都 `replace_dummy_variable`，否则会出现段错误（临时解决方案）
- Python 3.11 启用 `examples/graph_break.py`
- 单测全部开启 `MIN_GRAPH_SIZE=-1`，避免 Fallback 导致问题没有测到（动转静单测大多数可能都 Fallback 了）
- 修复错误的 space enum
- 启用单测 test_sir_rollback ❌ -> ✅