### PR TITLE
[Compat][3.11] support for-loop

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -48,7 +48,7 @@ from .function_graph import FunctionGraph
 from .guard import Guard
 from .instr_flag import FORMAT_VALUE_FLAG as FV
 from .instr_flag import MAKE_FUNCTION_FLAG as MF
-from .pycode_generator import PyCodeGen
+from .pycode_generator import JumpDirection, JumpSuffix, PyCodeGen
 from .tracker import (
     CellTracker,
     ConstTracker,
@@ -2104,12 +2104,14 @@ class OpcodeExecutor(OpcodeExecutorBase):
             self._graph.pycode_gen.gen_store(name, self._code)
 
         # 6. add jump if break
-        jump_if_break = self._graph.pycode_gen.gen_pop_forward_jump(
-            suffix="_IF_FALSE"
+        jump_if_break = self._graph.pycode_gen.gen_pop_jump(
+            direction=JumpDirection.FORWARD, suffix=JumpSuffix.FALSE
         )
 
         # 7. add JUMP_ABSOLUTE to FOR_ITER
-        self._graph.pycode_gen.gen_backward_jump(for_iter)
+        self._graph.pycode_gen.gen_jump(
+            for_iter, direction=JumpDirection.BACKWARD
+        )
         nop = self._graph.pycode_gen._add_instr("NOP")
         for_iter.jump_to = nop
         jump_if_break.jump_to = nop

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -793,7 +793,11 @@ class OpcodeExecutorBase:
         for ref in self.stack.peek[:2]:
             self.stack.push(ref)
 
-    def _rot_top_n(self, n):
+    def ROT_N(self, instr: Instruction):
+        assert instr.argval is not None
+        self._rot_top_n(instr.argval)
+
+    def _rot_top_n(self, n: int):
         # a1 a2 a3 ... an  <- TOS
         # the stack changes to
         # an a1 a2 a3 an-1 <- TOS

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -2104,20 +2104,12 @@ class OpcodeExecutor(OpcodeExecutorBase):
             self._graph.pycode_gen.gen_store(name, self._code)
 
         # 6. add jump if break
-        if sys.version_info >= (3, 11):
-            jump_if_break = self._graph.pycode_gen._add_instr(
-                "POP_JUMP_FORWARD_IF_FALSE"
-            )
-        else:
-            jump_if_break = self._graph.pycode_gen._add_instr(
-                "POP_JUMP_IF_FALSE"
-            )
+        jump_if_break = self._graph.pycode_gen.gen_pop_forward_jump(
+            suffix="_IF_FALSE"
+        )
 
         # 7. add JUMP_ABSOLUTE to FOR_ITER
-        if sys.version_info >= (3, 11):
-            self._graph.pycode_gen._add_instr("JUMP_BACKWARD", jump_to=for_iter)
-        else:
-            self._graph.pycode_gen._add_instr("JUMP_ABSOLUTE", jump_to=for_iter)
+        self._graph.pycode_gen.gen_backward_jump(for_iter)
         nop = self._graph.pycode_gen._add_instr("NOP")
         for_iter.jump_to = nop
         jump_if_break.jump_to = nop

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -875,7 +875,7 @@ class PyCodeGen:
 
     def gen_jump(
         self,
-        jump_to: Instruction | None,
+        jump_to: Instruction | None = None,
         *,
         direction: JumpDirection = JumpDirection.FORWARD,
     ) -> Instruction:

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -871,6 +871,35 @@ class PyCodeGen:
         else:
             raise NotImplementedError("swap is not supported before python3.11")
 
+    def gen_forward_jump(self, jump_to: Instruction) -> Instruction:
+        return self._add_instr("JUMP_BACKWARD", jump_to=jump_to)
+
+    def gen_backward_jump(self, jump_to: Instruction) -> Instruction:
+        if sys.version_info >= (3, 11):
+            return self._add_instr("JUMP_BACKWARD", jump_to=jump_to)
+        else:
+            return self._add_instr("JUMP_ABSOLUTE", jump_to=jump_to)
+
+    def gen_pop_forward_jump(
+        self, jump_to: Instruction | None = None, *, suffix: str = ""
+    ) -> Instruction:
+        assert jump_to is not None
+        if sys.version_info >= (3, 11):
+            return self._add_instr(f"POP_JUMP_FORWARD{suffix}", jump_to=jump_to)
+        else:
+            return self._add_instr(f"POP_JUMP{suffix}", jump_to=jump_to)
+
+    def gen_pop_backward_jump(
+        self, jump_to: Instruction | None = None, *, suffix: str = ""
+    ) -> Instruction:
+        assert jump_to is not None
+        if sys.version_info >= (3, 11):
+            return self._add_instr(
+                f"POP_JUMP_BACKWARD{suffix}", jump_to=jump_to
+            )
+        else:
+            return self._add_instr(f"POP_JUMP{suffix}", jump_to=jump_to)
+
     def gen_return(self):
         self._add_instr("RETURN_VALUE")
 

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -907,7 +907,9 @@ class PyCodeGen:
                 f"POP_JUMP_{direction.value}_IF_{suffix.value}", jump_to=jump_to
             )
         else:
-            return self._add_instr(f"POP_JUMP_{suffix}", jump_to=jump_to)
+            return self._add_instr(
+                f"POP_JUMP_IF_{suffix.value}", jump_to=jump_to
+            )
 
     def gen_return(self):
         self._add_instr("RETURN_VALUE")

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -876,7 +876,7 @@ class PyCodeGen:
 
     def gen_backward_jump(self, jump_to: Instruction) -> Instruction:
         if sys.version_info >= (3, 11):
-            return self._add_instr("JUMP_BACKWARD", jump_to=jump_to)
+            return self._add_instr("JUMP_FORWARD", jump_to=jump_to)
         else:
             return self._add_instr("JUMP_ABSOLUTE", jump_to=jump_to)
 

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -883,7 +883,6 @@ class PyCodeGen:
     def gen_pop_forward_jump(
         self, jump_to: Instruction | None = None, *, suffix: str = ""
     ) -> Instruction:
-        assert jump_to is not None
         if sys.version_info >= (3, 11):
             return self._add_instr(f"POP_JUMP_FORWARD{suffix}", jump_to=jump_to)
         else:
@@ -892,7 +891,6 @@ class PyCodeGen:
     def gen_pop_backward_jump(
         self, jump_to: Instruction | None = None, *, suffix: str = ""
     ) -> Instruction:
-        assert jump_to is not None
         if sys.version_info >= (3, 11):
             return self._add_instr(
                 f"POP_JUMP_BACKWARD{suffix}", jump_to=jump_to

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -871,38 +871,6 @@ class PyCodeGen:
         else:
             raise NotImplementedError("swap is not supported before python3.11")
 
-    def gen_jump(self, instr: Instruction, jump_to: Instruction) -> Instruction:
-        if sys.version_info >= (3, 11):
-            assert instr.offset is not None
-            assert jump_to.offset is not None
-            if instr.offset > jump_to.offset:
-                return self._add_instr("JUMP_BACKWARD", jump_to=jump_to)
-            elif instr.offset < jump_to.offset:
-                return self._add_instr("JUMP_FORWARD", jump_to=jump_to)
-            else:
-                raise InnerError("jump_to is the same as instr")
-        else:
-            return self._add_instr("JUMP_ABSOLUTE", jump_to=jump_to)
-
-    def gen_pop_jump(
-        self, instr: Instruction, jump_to: Instruction, *, suffix: str = ""
-    ):
-        if sys.version_info >= (3, 11):
-            assert instr.offset is not None
-            assert jump_to.offset is not None
-            if instr.offset > jump_to.offset:
-                return self._add_instr(
-                    f"POP_JUMP_BACKWARD{suffix}", jump_to=jump_to
-                )
-            elif instr.offset < jump_to.offset:
-                return self._add_instr(
-                    f"POP_JUMP_FORWARD{suffix}", jump_to=jump_to
-                )
-            else:
-                raise InnerError("jump_to is the same as instr")
-        else:
-            return self._add_instr(f"POP_JUMP{suffix}", jump_to=jump_to)
-
     def gen_return(self):
         self._add_instr("RETURN_VALUE")
 

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import sys
 import types
-from enum import Enum
 from typing import TYPE_CHECKING
 
 import opcode
@@ -35,24 +34,14 @@ from ..instruction_utils import (
 from ..instruction_utils.opcode_info import (
     PYOPCODE_CACHE_SIZE,
     UNCONDITIONAL_JUMP,
+    JumpDirection,
+    PopJumpCond,
 )
 
 if TYPE_CHECKING:
     from typing import Any
 
     from ..instruction_utils import Instruction
-
-
-class JumpDirection(Enum):
-    FORWARD = "FORWARD"
-    BACKWARD = "BACKWARD"
-
-
-class JumpSuffix(Enum):
-    FALSE = "FALSE"
-    TRUE = "TRUE"
-    NONE = "NONE"
-    NOT_NONE = "NOT_NONE"
 
 
 def get_pycode_attributes() -> list[str]:
@@ -886,7 +875,7 @@ class PyCodeGen:
 
     def gen_jump(
         self,
-        jump_to: Instruction,
+        jump_to: Instruction | None,
         *,
         direction: JumpDirection = JumpDirection.FORWARD,
     ) -> Instruction:
@@ -900,7 +889,7 @@ class PyCodeGen:
         jump_to: Instruction | None = None,
         *,
         direction: JumpDirection = JumpDirection.FORWARD,
-        suffix: JumpSuffix = JumpSuffix.NONE,
+        suffix: PopJumpCond = PopJumpCond.NONE,
     ) -> Instruction:
         if sys.version_info >= (3, 11):
             return self._add_instr(

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -861,6 +861,19 @@ class PyCodeGen:
         else:
             raise NotImplementedError("swap is not supported before python3.11")
 
+    def gen_jump(self, instr: Instruction, jump_to: Instruction):
+        if sys.version_info >= (3, 11):
+            assert instr.offset is not None
+            assert jump_to.offset is not None
+            if instr.offset > jump_to.offset:
+                return self._add_instr("JUMP_BACKWARD", jump_to=jump_to)
+            elif instr.offset < jump_to.offset:
+                return self._add_instr("JUMP_FORWARD", jump_to=jump_to)
+            else:
+                raise InnerError("jump_to is the same as instr")
+        else:
+            return self._add_instr("JUMP_ABSOLUTE", jump_to=jump_to)
+
     def gen_return(self):
         self._add_instr("RETURN_VALUE")
 

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -164,15 +164,15 @@ def correct_jump_direction(instr: Instruction) -> Instruction:
     Args:
         instr (Instruction): The instruction to be corrected.
     """
-    assert instr.offset is not None
+    assert instr.arg is not None
     if instr.opname in ABS_JUMP:
-        assert instr.offset > 0
+        assert instr.arg > 0
         return instr
     elif instr.opname in REL_JUMP:
-        if instr.offset < 0:
+        if instr.arg < 0:
             instr.opname = "JUMP_BACKWARD"
             instr.opcode = dis.opmap["JUMP_BACKWARD"]
-            instr.arg = -instr.offset
+            instr.arg = -instr.arg
         else:
             instr.opname = "JUMP_FORWARD"
             instr.opcode = dis.opmap["JUMP_FORWARD"]

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -172,7 +172,7 @@ def correct_jump_direction(instr: Instruction, arg: int) -> Instruction:
             if instr.opname == "JUMP_BACKWARD":
                 instr.opname = "JUMP_FORWARD"
                 instr.opcode = dis.opmap["JUMP_FORWARD"]
-            else:
+            elif instr.opname == "JUMP_FORWARD":
                 instr.opname = "JUMP_BACKWARD"
                 instr.opcode = dis.opmap["JUMP_BACKWARD"]
             instr.arg = -arg
@@ -213,13 +213,17 @@ def relocate_jump_target(instructions: list[Instruction]) -> None:
 
             if instr.opname in ABS_JUMP:
                 new_arg = jump_target
-            else:  # REL_JUMP
+            elif instr.opname == "JUMP_BACKWARD":
+                new_arg = instr.offset - jump_target + 2
+            else:
+                # other REL_JUMP, such as JUMP_FORWARD, FOR_ITER
                 new_arg = jump_target - instr.offset - 2
 
             if sys.version_info >= (3, 10):
                 new_arg //= 2
-
+            print(new_arg, jump_target, instr.offset)
             correct_jump_direction(instr, new_arg)
+            assert instr.arg is not None
             if extended_arg:
                 instr.arg &= 0xFF
                 new_arg = new_arg >> 8

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -186,7 +186,7 @@ def relocate_jump_target(instructions: list[Instruction]) -> None:
             if instr.opname in ABS_JUMP:
                 new_arg = jump_target
             elif instr.opname == "JUMP_BACKWARD":
-                new_arg = instr.offset - jump_target - 2
+                new_arg = instr.offset - jump_target + 2
                 if new_arg < 0:
                     # NOTE(zrr1999): in Python 3.11, JUMP_ABSOLUTE is removed, so we need to use JUMP_FORWARD instead,
                     # but in for loop breakgraph, we reuse JUMP_BACKWARD to jump forward, so we need to change it to JUMP_FORWARD.

--- a/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -5,7 +5,7 @@ import dis
 import sys
 from typing import TYPE_CHECKING, Any
 
-from .opcode_info import ALL_JUMP, REL_JUMP
+from .opcode_info import ABS_JUMP, ALL_JUMP
 
 if TYPE_CHECKING:
     import types
@@ -183,10 +183,14 @@ def relocate_jump_target(instructions: list[Instruction]) -> None:
             )
             assert jump_target is not None
 
-            if instr.opname in REL_JUMP:
+            if instr.opname == "JUMP_FORWARD":
                 new_arg = jump_target - instr.offset - 2
-            else:  # instr.opname in ABS_JUMP
+            elif instr.opname == "JUMP_BACKWARD":
+                new_arg = instr.offset - jump_target - 2
+            elif instr.opname in ABS_JUMP:
                 new_arg = jump_target
+            else:
+                raise ValueError(f"Unknown jump opcode: {instr.opname}")
 
             if sys.version_info >= (3, 10):
                 new_arg //= 2

--- a/sot/opcode_translator/instruction_utils/opcode_info.py
+++ b/sot/opcode_translator/instruction_utils/opcode_info.py
@@ -1,8 +1,11 @@
 import sys
+from enum import Enum
 
 import opcode
 
 REL_JUMP = {opcode.opname[x] for x in opcode.hasjrel}
+REL_BWD_JUMP = {opname for opname in REL_JUMP if "BACKWARD" in opname}
+REL_FWD_JUMP = REL_JUMP - REL_BWD_JUMP
 ABS_JUMP = {opcode.opname[x] for x in opcode.hasjabs}
 HAS_LOCAL = {opcode.opname[x] for x in opcode.haslocal}
 HAS_FREE = {opcode.opname[x] for x in opcode.hasfree}
@@ -10,6 +13,18 @@ ALL_JUMP = REL_JUMP | ABS_JUMP
 UNCONDITIONAL_JUMP = {"JUMP_ABSOLUTE", "JUMP_FORWARD"}
 if sys.version_info >= (3, 11):
     UNCONDITIONAL_JUMP.add("JUMP_BACKWARD")
+
+
+class JumpDirection(Enum):
+    FORWARD = "FORWARD"
+    BACKWARD = "BACKWARD"
+
+
+class PopJumpCond(Enum):
+    FALSE = "FALSE"
+    TRUE = "TRUE"
+    NONE = "NONE"
+    NOT_NONE = "NOT_NONE"
 
 
 # Cache for some opcodes, it's for Python 3.11+

--- a/sot/utils/utils.py
+++ b/sot/utils/utils.py
@@ -263,8 +263,8 @@ class GraphLogger:
     def clear(self):
         self.graph_num = 0
         self.op_num = 0
-        self.graphs: list = []
-        self.ops: list = []
+        self.graphs = []
+        self.ops = []
 
     def get_graph_num(self):
         return self.graph_num

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -12,7 +12,6 @@ py311_skiped_tests=(
     ./test_19_closure.py
     ./test_guard_user_defined_fn.py
     ./test_resnet.py
-    ./test_resnet50_backward.py
     ./test_tensor_dtype_in_guard.py
 )
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -9,17 +9,11 @@ echo "IS_PY311:" $IS_PY311
 failed_tests=()
 
 py311_skiped_tests=(
-    ./test_15_slice.py
     ./test_19_closure.py
-    ./test_21_global.py
     ./test_constant_graph.py
-    ./test_enumerate.py
     ./test_guard_user_defined_fn.py
-    ./test_inplace_api.py
-    ./test_range.py
     ./test_resnet.py
     ./test_resnet50_backward.py
-    # ./test_side_effects.py        There are some case need to be fixed
     ./test_tensor_dtype_in_guard.py
 )
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -9,7 +9,6 @@ echo "IS_PY311:" $IS_PY311
 failed_tests=()
 
 py311_skiped_tests=(
-    ./test_12_for_loop.py
     ./test_15_slice.py
     ./test_19_closure.py
     ./test_21_global.py

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import unittest
 
 from test_case_base import TestCaseBase, strict_mode_guard
@@ -234,10 +233,6 @@ class TestListSideEffect(TestCaseBase):
             list_reverse, [-1, 2, -3, 4, -5, 6, -7, 8, -9]
         )
 
-    @unittest.skipIf(
-        sys.version_info >= (3, 11),
-        "Python 3.11+ not support for-loop breakgraph",
-    )
     def test_slice_in_for_loop(self):
         x = 2
         with strict_mode_guard(0):
@@ -247,9 +242,6 @@ class TestListSideEffect(TestCaseBase):
         self.assert_results_with_side_effects(list_nested, [1, 2, 3])
 
 
-@unittest.skipIf(
-    sys.version_info >= (3, 11), "Python 3.11+ not support for-loop breakgraph"
-)
 class TestSliceAfterChange(TestCaseBase):
     def test_slice_list_after_change(self):
         self.assert_results_with_side_effects(


### PR DESCRIPTION
1. 前移 _current_line 初始化为 -1 的语句，使得当 get_instructions 函数中发生错误时依然可以正确返回报错栈。
2. 实现 gen_jump、gen_pop_jump，简化后期适配操作。
3. fix _break_graph_in_for_loop in python3.11, 将以前固定的jump（大多数为绝对跳转），改为根据方向调整jump指令（python3.11新指令）。
4. 修复 relocate_jump_target，使其可以正确计算JUMP_BACKWARD的参数。
5. 启用如下单测
    - test_12_for_loop ❌ -> ✅
    - test_15_slice ❌ -> ✅
    - test_21_global ❌ -> ✅
    - test_enumerate ❌ -> ✅
    - test_inplace_api ❌ -> ✅
    - test_range ❌ -> ✅
    - test_resnet50_backward ❌ -> ✅
    - test_side_effects 🚧 -> ✅