### PR TITLE
[Compat][3.11] gen `KW_NAMES` when call breakgraph, enable `test_constant_graph.py`

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -107,7 +107,7 @@ SUPPORT_COMPARE_OP = {
 
 @dataclass
 class Stop:
-    state: bool
+    state: str
 
 
 @Singleton

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -1225,7 +1225,6 @@ class OpcodeExecutorBase:
         is_method = not isinstance(self.stack.peek[instr.arg + 2], NullVariable)
         total_args = instr.arg + int(is_method)
         kwnames = self._call_shape if self._call_shape is not None else []
-        self._call_shape = None
         n_kwargs = len(kwnames)
         n_positional_args = total_args - n_kwargs
         kwargs_list = self.stack.pop_n(n_kwargs)
@@ -1236,6 +1235,7 @@ class OpcodeExecutorBase:
             # pop the NULL variable
             self.stack.pop()
         self.stack.push(fn(*args, **kwargs))
+        self._call_shape = None
 
     def CALL_FUNCTION(self, instr: Instruction):
         assert isinstance(instr.arg, int)
@@ -1870,6 +1870,8 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 var_loader.load(stack_arg)
 
         # gen call resume fn opcode
+        # NOTE(SigureMo): In Python 3.11，we need generate KW_NAMES if the call shape is not None.
+        self._graph.pycode_gen.gen_kw_names(self._call_shape)
         self._graph.pycode_gen.add_pure_instructions([instr])
         self.stack.pop_n(pop_n)
         stack_size = len(self.stack) + push_n

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -790,7 +790,7 @@ class PyCodeGen:
         if kw_names is None:
             return
         if sys.version_info < (3, 11):
-            raise InnerError("gen_kwnames is not supported before python3.11")
+            raise InnerError("gen_kw_names is not supported before python3.11")
         if kw_names not in self._code_options["co_consts"]:
             self._code_options["co_consts"].append(kw_names)
         idx = self._code_options["co_consts"].index(kw_names)

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -786,6 +786,16 @@ class PyCodeGen:
         else:
             self._add_instr("CALL_METHOD", arg=argc, argval=argc)
 
+    def gen_kw_names(self, kw_names: tuple[str, ...] | None):
+        if kw_names is None:
+            return
+        if sys.version_info < (3, 11):
+            raise InnerError("gen_kwnames is not supported before python3.11")
+        if kw_names not in self._code_options["co_consts"]:
+            self._code_options["co_consts"].append(kw_names)
+        idx = self._code_options["co_consts"].index(kw_names)
+        self._add_instr("KW_NAMES", arg=idx, argval=kw_names)
+
     def gen_pop_top(self):
         self._add_instr("POP_TOP")
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -13,7 +13,6 @@ py311_skiped_tests=(
     ./test_15_slice.py
     ./test_19_closure.py
     ./test_21_global.py
-    ./test_constant_graph.py
     ./test_enumerate.py
     ./test_guard_user_defined_fn.py
     ./test_inplace_api.py

--- a/tests/test_constant_graph.py
+++ b/tests/test_constant_graph.py
@@ -24,7 +24,7 @@ def func_2(format_str, tensor):
     return str, tensor
 
 
-class TestExecutor(TestCaseBase):
+class TestConstantGraph(TestCaseBase):
     def test_case_1(self):
         x = "{xx} is xx"
         tensor = paddle.to_tensor(1)


### PR DESCRIPTION
3.11 在发生 `CALL` 子图打断的时候，除去当前模拟栈、相关 Variable，还会依赖 `KW_NAMES` 注册的 `call_shape`，因此如果生成的代码里不包含 `KW_NAMES` 是会认为是不含 kwargs 的调用，大概率就会发生段错误，因此 `KW_NAMES` 是需要恢复到生成的字节码里的

原来 `KW_NAMES` 的模拟执行会提前将 `call_shape` 设回 None，导致发生打断时其总是 None，因此调整为 `CALL` 完成后才设回 None

- test_constant_graph.py ❌ -> ✅

