### PR TITLE
[Compat][3.11] support POP_JUMP for `is None` and `is not None`

### DIFF
--- a/sot/opcode_translator/executor/dispatch_functions.py
+++ b/sot/opcode_translator/executor/dispatch_functions.py
@@ -28,5 +28,13 @@ def operator_BAD(left, right):
     pass
 
 
+def operator_is_none(val):
+    pass
+
+
+def operator_is_not_none(val):
+    pass
+
+
 def tensor_numel(x):
     pass

--- a/sot/opcode_translator/executor/variable_dispatch.py
+++ b/sot/opcode_translator/executor/variable_dispatch.py
@@ -15,6 +15,8 @@ from ...utils.magic_methods import (
 )
 from .dispatch_functions import (
     operator_in,
+    operator_is_none,
+    operator_is_not_none,
     operator_not_in,
     raise_break_graph_fn,
     tensor_numel,
@@ -689,6 +691,25 @@ def is_not_func(var: VariableBase, other: VariableBase):
             f"Not found implementation operator.is for {var} and {other}."
         )
     return handler(var, other).bool_not()
+
+
+# is None
+Dispatcher.register(
+    operator_is_none,
+    ("VariableBase",),
+    lambda var: BuiltinVariable(operator.is_, var.graph, DanglingTracker())(
+        var, ConstantVariable.wrap_literal(None, var.graph)
+    ),
+)
+
+# is not None
+Dispatcher.register(
+    operator_is_not_none,
+    ("VariableBase",),
+    lambda var: BuiltinVariable(operator.is_not, var.graph, DanglingTracker())(
+        var, ConstantVariable.wrap_literal(None, var.graph)
+    ),
+)
 
 
 # NOTE(SigureMo): Don't directly capture free var inside for-loop, use partial instead.

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -10,8 +10,6 @@ failed_tests=()
 
 py311_skiped_tests=(
     ./test_19_closure.py
-    ./test_guard_user_defined_fn.py
-    ./test_resnet.py
     ./test_tensor_dtype_in_guard.py
 )
 


### PR DESCRIPTION
因为 3.11 增加了 `POP_JUMP_IF_*_NONE` 和 `POP_JUMP_IF_*_NOT_NONE`，对于大多数情况来说它们不是 Constant 和 Container，因此会 Fallback

这里利用 dispatch 消除了 Constant 和 Container 的特判，POP_JUMP 相比于之前支持的情况应该会更多了

启用如下单测：

- test_guard_user_defined_fn ❌ -> ✅
- test_resnet ❌ -> ✅