### PR TITLE
rename SOT exceptions

### DIFF
--- a/sot/opcode_translator/breakpoint.py
+++ b/sot/opcode_translator/breakpoint.py
@@ -35,7 +35,7 @@ class BreakpointManager:
 
     def add_event(self, event):
         """
-        event in ['All' ,'NotImplementException', 'BreakGraphError', 'InnerError']
+        event in ['All' ,'FallbackError', 'BreakGraphError', 'InnerError']
         """
         self.record_event.append(event)
 

--- a/sot/opcode_translator/executor/dispatch_functions.py
+++ b/sot/opcode_translator/executor/dispatch_functions.py
@@ -1,6 +1,6 @@
 # This file stores the customed function that will be called by the dispatch mechanism.
 
-from ...utils import BreakGraphError, NotImplementException
+from ...utils import BreakGraphError, FallbackError
 
 
 def raise_break_graph_fn(*args, **kwarg):
@@ -8,7 +8,7 @@ def raise_break_graph_fn(*args, **kwarg):
 
 
 def raise_not_implement_fn(*args, **kwarg):
-    raise NotImplementException("raise by raise_break_graph_fn.")
+    raise FallbackError("raise by raise_break_graph_fn.")
 
 
 # just a function for operator.in

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -18,8 +18,8 @@ from ...psdb import NO_BREAKGRAPH_CODES, NO_FALLBACK_CODES
 from ...utils import (
     BreakGraphError,
     EventGuard,
+    FallbackError,
     InnerError,
-    NotImplementException,
     OrderedSet,
     Singleton,
     SotUndefinedVar,
@@ -295,13 +295,13 @@ def start_translate(frame: types.FrameType, **kwargs) -> GuardedFunction:
         try:
             new_custom_code, guard_fn = simulator.transform()
             return new_custom_code, guard_fn
-        # TODO(zrr1999): InnerError maybe place before (NotImplementException, BreakGraphError)
+        # TODO(zrr1999): InnerError maybe place before (FallbackError, BreakGraphError)
         # TODO(0x45f): handle BreakGraphError to trigger fallback
         except BreakGraphError as e:
             raise RuntimeError(
                 f"Found BreakGraphError raised, it should not be catch at start_translate!\n{e}"
             )
-        except NotImplementException as e:
+        except FallbackError as e:
             if simulator._code in NO_FALLBACK_CODES:
                 raise InnerError(
                     f"{simulator._code.co_name} should not fallback, but got '{e}'"
@@ -424,7 +424,7 @@ def pop_jump_if_op_wrapper(fns: list[Callable[[Any], Any]]):
                 assert instr.jump_to is not None
                 self.jump_to(instr.jump_to)
         except BreakGraphError:
-            raise NotImplementException(
+            raise FallbackError(
                 f"Currently don't support predicate {pred_obj.__class__.__name__}"
             )
 
@@ -509,7 +509,7 @@ def fallback_when_occur_error(fn: Callable):
         try:
             return fn(*args, **kwargs)
         except Exception as e:
-            raise NotImplementException(
+            raise FallbackError(
                 f'[Fallback] An exception occurred when processing break graph, fallback to dygraph, error message is: \n{type(e)} : {e}\n'
             )
 
@@ -744,15 +744,13 @@ class OpcodeExecutorBase:
             True if execution should stop, False otherwise.
 
         Raises:
-            NotImplementException: If the opcode is not supported.
+            FallbackError: If the opcode is not supported.
 
         """
         if instr.starts_line is not None:
             self._current_line = instr.starts_line
         if not hasattr(self, instr.opname):
-            raise NotImplementException(
-                f"opcode: {instr.opname} is not supported."
-            )
+            raise FallbackError(f"opcode: {instr.opname} is not supported.")
         log_message = f"[Translate {self._name}]: (line {self._current_line:>3}) {instr.opname:<12} {instr.argval}, stack is {self.stack}\n"
         log(3, log_message)
         code_file = self._code.co_filename
@@ -1374,7 +1372,7 @@ class OpcodeExecutorBase:
             related_list.append(self.stack.pop())
 
         if flag & MF.MF_HAS_KWDEFAULTS:
-            raise NotImplementException(
+            raise FallbackError(
                 "Found need func_kwdefaults when MAKE_FUNCTION."
             )
 
@@ -1450,7 +1448,7 @@ class OpcodeExecutorBase:
             else:
                 self.stack.pop()
             return
-        raise NotImplementException(
+        raise FallbackError(
             "Currently don't support predicate a non-const / non-tensor obj."
         )
 
@@ -1466,7 +1464,7 @@ class OpcodeExecutorBase:
             else:
                 self.stack.pop()
             return
-        raise NotImplementException(
+        raise FallbackError(
             "Currently don't support predicate a non-const / non-tensor obj."
         )
 
@@ -1499,9 +1497,7 @@ class OpcodeExecutorBase:
         if not isinstance(
             sequence, (ListVariable, TupleVariable, TensorVariable)
         ):
-            raise NotImplementException(
-                f"Unpack {sequence} is not implemented."
-            )
+            raise FallbackError(f"Unpack {sequence} is not implemented.")
 
         assert (
             len(sequence) == instr.arg
@@ -1523,9 +1519,7 @@ class OpcodeExecutorBase:
         if not isinstance(
             sequence, (ListVariable, TupleVariable, TensorVariable)
         ):
-            raise NotImplementException(
-                f"Unpack {sequence} is not implemented."
-            )
+            raise FallbackError(f"Unpack {sequence} is not implemented.")
 
         if instr.argval >= 256:
             # NOTE: If the number of unpacked variables exceeds 256, python will report an error like:
@@ -1598,9 +1592,7 @@ class OpcodeExecutorBase:
                 ConstantVariable(result, self._graph, DummyTracker([value]))
             )
         else:
-            raise NotImplementException(
-                f"Do not support format {type(value)} now"
-            )
+            raise FallbackError(f"Do not support format {type(value)} now")
 
     # NOTE: This operation will generate SideEffects, and the mechanism has not been completed yet
     def DICT_UPDATE(self, instr: Instruction):
@@ -1919,7 +1911,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         # stopped by RETURN_VALUE and has sir len is enough => disable_eval_frame
         simulate_complete = bool(self.stop_state == "Return")
         if simulate_complete and self.graph_size() < min_graph_size():
-            raise NotImplementException(
+            raise FallbackError(
                 "Fallback after simulate for reasons.", disable_eval_frame=True
             )
         else:
@@ -2244,9 +2236,7 @@ class OpcodeExecutor(OpcodeExecutorBase):
         end = self.indexof(instr.jump_to)
         for i in range(start, end):
             if self._instructions[i].opname == "RETURN_VALUE":
-                raise NotImplementException(
-                    "Found RETURN_VALUE in for loop body."
-                )
+                raise FallbackError("Found RETURN_VALUE in for loop body.")
 
         self._graph.add_global_guarded_variable(iterator)
 

--- a/sot/opcode_translator/executor/pycode_generator.py
+++ b/sot/opcode_translator/executor/pycode_generator.py
@@ -14,8 +14,8 @@ import opcode
 import paddle
 
 from ...utils import (
+    FallbackError,
     InnerError,
-    NotImplementException,
     OrderedSet,
     ResumeFnNameFactory,
     is_clean_code,
@@ -487,9 +487,7 @@ class PyCodeGen:
 
         new_code = self.gen_pycode()
         if len(new_code.co_freevars) + len(new_code.co_cellvars) > 0:
-            raise NotImplementException(
-                "Break graph in closure is not support."
-            )
+            raise FallbackError("Break graph in closure is not support.")
         fn = types.FunctionType(new_code, self._f_globals, fn_name)
 
         return fn, inputs
@@ -551,9 +549,7 @@ class PyCodeGen:
         ] = f"#{fn_name}@{self._code_options['co_name'][1:]}"
         new_code = self.gen_pycode()
         if len(new_code.co_freevars) + len(new_code.co_cellvars) > 0:
-            raise NotImplementException(
-                "Break graph in closure is not support."
-            )
+            raise FallbackError("Break graph in closure is not support.")
         fn = types.FunctionType(new_code, self._f_globals, fn_name)
         return fn
 

--- a/sot/opcode_translator/executor/variable_dispatch.py
+++ b/sot/opcode_translator/executor/variable_dispatch.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import paddle
 
-from ...utils import BreakGraphError, NotImplementException
+from ...utils import BreakGraphError, FallbackError
 from ...utils.magic_methods import (
     BINARY_OPS,
     UNARY_OPS,
@@ -687,7 +687,7 @@ Dispatcher.register(
 def is_not_func(var: VariableBase, other: VariableBase):
     handler = Dispatcher.dispatch(operator.is_, var, other)
     if handler is None:
-        raise NotImplementException(
+        raise FallbackError(
             f"Not found implementation operator.is for {var} and {other}."
         )
     return handler(var, other).bool_not()
@@ -828,9 +828,7 @@ for binary_fn in BINARY_OPS:
                         raise BreakGraphError(
                             "(ConstantVariable % TensorVariable) raise a callback. "
                         )
-                    raise NotImplementException(
-                        "Tensor doesn't support __rmod__"
-                    )
+                    raise FallbackError("Tensor doesn't support __rmod__")
 
             else:
                 Dispatcher.register(
@@ -852,9 +850,7 @@ for unary_fn in UNARY_OPS:
 
         @Dispatcher.register_decorator(unary_fn)
         def numpy_unary_dispatcher(var: NumpyVariable):
-            raise NotImplementException(
-                'Numpy operator need fallback to dygraph'
-            )
+            raise FallbackError('Numpy operator need fallback to dygraph')
 
 
 for binary_fn in BINARY_OPS:
@@ -862,9 +858,7 @@ for binary_fn in BINARY_OPS:
 
         @Dispatcher.register_decorator(binary_fn)
         def numpy_binary_dispatcher(var: NumpyVariable, other: NumpyVariable):
-            raise NotImplementException(
-                'Numpy operator need fallback to dygraph'
-            )
+            raise FallbackError('Numpy operator need fallback to dygraph')
 
 
 # Register dispatch for DataVariable: directy call and return a wrapped variable.

--- a/sot/opcode_translator/executor/variables/base.py
+++ b/sot/opcode_translator/executor/variables/base.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 import paddle
 
 from ....utils import NameGenerator, event_register, get_unbound_method, log
-from ....utils.exceptions import HasNoAttributeError, NotImplementException
+from ....utils.exceptions import FallbackError, HasNoAttributeError
 from ..dispatcher import Dispatcher
 from ..guard import StringifyExpression, check_guard, union_free_vars
 from ..mutable_data import MutableDictLikeData
@@ -374,7 +374,7 @@ class VariableBase:
         """
         Abstract method to construct an opcode and append it into codegen.instructions
         """
-        raise NotImplementException(
+        raise FallbackError(
             f'{self.__class__.__name__} does not implement "_reconstruct" method'
         )
 
@@ -494,7 +494,7 @@ class VariableBase:
         return self.setitem(key, value)
 
     def setitem(self, key, value):
-        raise NotImplementException(f"{self} is not support setitem.")
+        raise FallbackError(f"{self} is not support setitem.")
 
     def __repr__(self):
         info = {**self.main_info, **self.debug_info}

--- a/sot/opcode_translator/executor/variables/basic.py
+++ b/sot/opcode_translator/executor/variables/basic.py
@@ -13,8 +13,8 @@ from ....infer_meta import MetaInfo
 from ....symbolic.statement_ir import Symbol
 from ....utils import (
     BreakGraphError,
+    FallbackError,
     NameGenerator,
-    NotImplementException,
     paddle_tensor_methods,
 )
 from ....utils.exceptions import HasNoAttributeError, InnerError
@@ -467,7 +467,7 @@ class TensorVariable(VariableBase):
 
     def getattr(self, name: str, default=None):
         if default is not None:
-            raise NotImplementException(
+            raise FallbackError(
                 "default argument for getattr is not implemented"
             )
         method_name_to_builtin_fn = {
@@ -726,7 +726,7 @@ class NumpyVariable(VariableBase):
                 ),
             ]
         else:
-            raise NotImplementException(
+            raise FallbackError(
                 "We can not stringify numpy variable when value is np.ndarray"
             )
 

--- a/sot/opcode_translator/executor/variables/callable.py
+++ b/sot/opcode_translator/executor/variables/callable.py
@@ -19,11 +19,7 @@ from ....utils import (
     is_paddle_api,
     magic_method_builtin_dispatch,
 )
-from ....utils.exceptions import (
-    BreakGraphError,
-    FallbackErrorBase,
-    NotImplementException,
-)
+from ....utils.exceptions import BreakGraphError, FallbackError, SotErrorBase
 from ..dispatcher import Dispatcher
 from ..guard import (
     StringifyExpression,
@@ -150,7 +146,7 @@ class UserDefinedFunctionVariable(FunctionVariable):
         elif self.value is psdb.breakgraph:
             raise BreakGraphError("breakgraph by psdb.breakgraph")
         elif self.value is psdb.fallback:
-            raise NotImplementException("fallback by psdb.fallback")
+            raise FallbackError("fallback by psdb.fallback")
         return None
 
     def call_function(self, /, *args, **kwargs) -> VariableBase:
@@ -167,7 +163,7 @@ class UserDefinedFunctionVariable(FunctionVariable):
                 f"Inline Call: {inline_executor._code.co_name.replace('<', '(').replace('>', ')')}, file {inline_executor._code.co_filename}, line {int(inline_executor._code.co_firstlineno)}"
             ):
                 output = inline_executor.inline_call()
-        except FallbackErrorBase as e:
+        except SotErrorBase as e:
             self.graph.restore_memo(checkpoint)
             raise BreakGraphError(
                 f"{self.value} is raise a inline call error. {e}"

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from functools import reduce
 from typing import TYPE_CHECKING, Any
 
-from ....utils.exceptions import InnerError, NotImplementException
+from ....utils.exceptions import FallbackError, InnerError
 from ..dispatcher import Dispatcher
 from ..guard import StringifyExpression, check_guard
 from ..mutable_data import MutableDictLikeData, MutableListLikeData
@@ -36,17 +36,13 @@ class ContainerVariable(VariableBase):
         return self.value
 
     def get_items(self) -> list[VariableBase]:
-        raise NotImplementException(
-            'ContainerVariable.get_items do not implement'
-        )
+        raise FallbackError('ContainerVariable.get_items do not implement')
 
     def get_wrapped_items(self):
-        raise NotImplementException()
+        raise FallbackError()
 
     def __len__(self):
-        raise NotImplementException(
-            'ContainerVariable.__len__ do not implement'
-        )
+        raise FallbackError('ContainerVariable.__len__ do not implement')
 
     def len(self):
         return ConstantVariable(len(self), self.graph, DummyTracker([self]))
@@ -404,7 +400,7 @@ class ListVariable(ContainerVariable):
         from .callable import BuiltinVariable
 
         if default is not None:
-            raise NotImplementException(
+            raise FallbackError(
                 "default argument for getattr is not implemented"
             )
 
@@ -428,9 +424,7 @@ class ListVariable(ContainerVariable):
                 builtin_fn, self.graph, DanglingTracker()
             ).bind(self, name)
         else:
-            raise NotImplementException(
-                f"attribute {name} for list is not implemented"
-            )
+            raise FallbackError(f"attribute {name} for list is not implemented")
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):
@@ -469,7 +463,7 @@ class TupleVariable(ContainerVariable):
         from .callable import BuiltinVariable
 
         if default is not None:
-            raise NotImplementException(
+            raise FallbackError(
                 "default argument for getattr is not implemented"
             )
 
@@ -483,7 +477,7 @@ class TupleVariable(ContainerVariable):
                 builtin_fn, self.graph, DanglingTracker()
             ).bind(self, name)
         else:
-            raise NotImplementException(
+            raise FallbackError(
                 f"attribute {name} for tuple is not implemented"
             )
 
@@ -967,7 +961,7 @@ class DictVariable(ContainerVariable):
         from .callable import BuiltinVariable
 
         if default is not None:
-            raise NotImplementException(
+            raise FallbackError(
                 "default argument for getattr is not implemented"
             )
 
@@ -990,9 +984,7 @@ class DictVariable(ContainerVariable):
                 builtin_fn, self.graph, DanglingTracker()
             ).bind(self, name)
         else:
-            raise NotImplementException(
-                f"attribute {name} for dict is not implemented"
-            )
+            raise FallbackError(f"attribute {name} for dict is not implemented")
 
     @VariableFactory.register_from_value()
     def from_value(value: Any, graph: FunctionGraph, tracker: Tracker):

--- a/sot/opcode_translator/executor/variables/iter.py
+++ b/sot/opcode_translator/executor/variables/iter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ....utils import NotImplementException
+from ....utils import FallbackError
 from ..pycode_generator import PyCodeGen
 from ..tracker import ConstTracker, DummyTracker
 from .base import VariableBase
@@ -59,9 +59,7 @@ class SequenceIterVariable(IterVariable):
 
     def to_list(self) -> list:
         if self.has_side_effect():
-            raise NotImplementException(
-                "Can not convert an used iterator into list"
-            )
+            raise FallbackError("Can not convert an used iterator into list")
         self.idx = len(self.hold)
         retval = []
         for i in range(len(self.hold)):

--- a/sot/utils/__init__.py
+++ b/sot/utils/__init__.py
@@ -1,7 +1,7 @@
 from .exceptions import (
     BreakGraphError,
+    FallbackError,
     InnerError,
-    NotImplementException,
     inner_error_default_handler,
 )
 from .magic_methods import magic_method_builtin_dispatch
@@ -51,7 +51,7 @@ from .utils import (
 
 __all__ = [
     "InnerError",
-    "NotImplementException",
+    "FallbackError",
     "BreakGraphError",
     "Singleton",
     "NameGenerator",

--- a/sot/utils/exceptions.py
+++ b/sot/utils/exceptions.py
@@ -1,7 +1,7 @@
 import traceback
 
 
-class FallbackErrorBase(Exception):
+class SotErrorBase(Exception):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         from ..opcode_translator.breakpoint import BreakpointManager
@@ -13,7 +13,7 @@ class FallbackErrorBase(Exception):
         print("".join(lines))
 
 
-class InnerError(FallbackErrorBase):
+class InnerError(SotErrorBase):
     pass
 
 
@@ -21,14 +21,14 @@ class HasNoAttributeError(InnerError):
     pass
 
 
-class NotImplementException(FallbackErrorBase):
+class FallbackError(SotErrorBase):
     def __init__(self, msg, disable_eval_frame=False):
         super().__init__(msg)
         self.disable_eval_frame = False
 
 
 # raise in inline function call strategy.
-class BreakGraphError(FallbackErrorBase):
+class BreakGraphError(SotErrorBase):
     pass
 
 


### PR DESCRIPTION
rename SOT 相关异常名，使整体报错语义更加清晰

- `FallbackErrorBase` -> `SotErrorBase`
- `NotImplementException` -> `FallbackError`