### PR TITLE
enable some skipped dy2st unittests

### DIFF
--- a/.github/workflows/paddle_ci.yaml
+++ b/.github/workflows/paddle_ci.yaml
@@ -59,6 +59,7 @@ jobs:
           git checkout ${PADDLE_COMMIT_HASH}
           # skip new ir tests
           sed -i "s/@test_with_new_ir/@unittest.skip('skip new ir test')/g" `grep -rl "@test_with_new_ir" test/dygraph_to_static`
+          sed -i "s/@test_and_compare_with_new_ir/# @test_and_compare_with_new_ir/g" `grep -rl "@test_and_compare_with_new_ir" test/dygraph_to_static`
 
       - name: Run unit tests
         working-directory: ./tests/

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -2257,8 +2257,12 @@ class OpcodeExecutor(OpcodeExecutorBase):
             return Stop(state="BreakGraph")
 
     @call_break_graph_decorator(push_n=0)
-    def STORE_ATTR(self, instr):
+    def STORE_ATTR(self, instr: Instruction):
         super().STORE_ATTR(instr)
+
+    @call_break_graph_decorator(push_n=0)
+    def STORE_SUBSCR(self, instr: Instruction):
+        super().STORE_SUBSCR(instr)
 
     @call_break_graph_decorator(push_n=1)
     def CALL(self, instr: Instruction):

--- a/sot/utils/exceptions.py
+++ b/sot/utils/exceptions.py
@@ -40,8 +40,11 @@ def inner_error_default_handler(func, message_fn):
             return func(*args, **kwargs)
         except Exception as e:
             message = message_fn(*args, **kwargs)
+            origin_exception_message = "\n".join(
+                traceback.format_exception(type(e), e, e.__traceback__)
+            )
             raise InnerError(
-                f"{message}.\nOrigin Exception is : \n {traceback.format_exception(type(e), e, e.__traceback__)}"
+                f"{message}.\nOrigin Exception is: \n {origin_exception_message}"
             ) from e
 
     return impl

--- a/sot/utils/paddle_api_config.py
+++ b/sot/utils/paddle_api_config.py
@@ -44,7 +44,7 @@ def get_paddle_api():
         paddle.is_grad_enabled,
     ]
     # TODO: users should not call static_apis, but we need to use, so add static_apis here temporary
-    static_apis = [paddle.static.setitem]
+    static_apis = [paddle.static.setitem, paddle.static.accuracy]
     paddle_api_list = []
     for module in modules:
         for fn_name in getattr(module, "__all__", []):

--- a/tests/run_all_paddle_ci.sh
+++ b/tests/run_all_paddle_ci.sh
@@ -20,15 +20,14 @@ disabled_tests=(
     ${PADDLE_TEST_BASE}/test_ptb_lm.py # There is accuracy problem of the model in SOT
     ${PADDLE_TEST_BASE}/test_ptb_lm_v2.py # There is accuracy problem of the model in SOT
     ${PADDLE_TEST_BASE}/test_cycle_gan.py # This test has a precision problem when it reaches the maximum cache size
-    ${PADDLE_TEST_BASE}/test_inplace_assign.py # This test waiting for #301
     # These unittests are introduced after #347, fix them later
-    ${PADDLE_TEST_BASE}/test_backward_without_params.py
-    ${PADDLE_TEST_BASE}/test_bert.py
-    ${PADDLE_TEST_BASE}/test_cpu_cuda_to_tensor.py
-    ${PADDLE_TEST_BASE}/test_jit_setitem.py
-    ${PADDLE_TEST_BASE}/test_mnist_amp.py
-    ${PADDLE_TEST_BASE}/test_to_tensor.py
-    ${PADDLE_TEST_BASE}/test_yolov3.py
+    # ${PADDLE_TEST_BASE}/test_backward_without_params.py
+    # ${PADDLE_TEST_BASE}/test_bert.py
+    # ${PADDLE_TEST_BASE}/test_cpu_cuda_to_tensor.py
+    # ${PADDLE_TEST_BASE}/test_jit_setitem.py
+    # ${PADDLE_TEST_BASE}/test_mnist_amp.py
+    # ${PADDLE_TEST_BASE}/test_to_tensor.py
+    # ${PADDLE_TEST_BASE}/test_yolov3.py
 )
 
 for file in ${PADDLE_TEST_BASE}/*.py; do

--- a/tests/run_all_paddle_ci.sh
+++ b/tests/run_all_paddle_ci.sh
@@ -21,13 +21,8 @@ disabled_tests=(
     ${PADDLE_TEST_BASE}/test_ptb_lm_v2.py # There is accuracy problem of the model in SOT
     ${PADDLE_TEST_BASE}/test_cycle_gan.py # This test has a precision problem when it reaches the maximum cache size
     # These unittests are introduced after #347, fix them later
-    # ${PADDLE_TEST_BASE}/test_backward_without_params.py
-    # ${PADDLE_TEST_BASE}/test_bert.py
-    # ${PADDLE_TEST_BASE}/test_cpu_cuda_to_tensor.py
-    # ${PADDLE_TEST_BASE}/test_jit_setitem.py
-    # ${PADDLE_TEST_BASE}/test_mnist_amp.py
-    # ${PADDLE_TEST_BASE}/test_to_tensor.py
-    # ${PADDLE_TEST_BASE}/test_yolov3.py
+    ${PADDLE_TEST_BASE}/test_cpu_cuda_to_tensor.py
+    ${PADDLE_TEST_BASE}/test_to_tensor.py
 )
 
 for file in ${PADDLE_TEST_BASE}/*.py; do


### PR DESCRIPTION
启用如下 6 个动转静单测

- 注释掉 clone 下的 dy2st 单测新加的 `@test_and_compare_with_new_ir` 装饰器，应该是 SOT 和新 IR 联调出的问题
    - `test_backward_without_params`
    - `test_yolov3`
- `test_inplace_assign` 应该之前忘记解开了
    - `test_inplace_assign`
- 将 `paddle.static.accuracy` 也放到 Paddle API 里，部分单测用了这个 API，此前会模拟，进而出错
    - `test_bert`
    - `test_mnist_amp`
- `STORE_ATTR` 也可能 breakgraph，因此加装饰器捕获 breakgraph error
    - `test_jit_setitem`