### PR TITLE
enable `to_tensor` dy2st unittests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ paddle-test = [
     "opencv-python",
     "scipy",
     "pyyaml",
+    "gym==0.25.2",
 ]
 
 [tool.setuptools.packages]

--- a/sot/opcode_translator/executor/guard.py
+++ b/sot/opcode_translator/executor/guard.py
@@ -98,7 +98,7 @@ def support_weak_ref(obj):
 def check_guard(
     fn: Callable[[CheckGuardInputT], list[StringifyExpression]]
 ) -> Callable[[CheckGuardInputT], list[StringifyExpression]]:
-    def wrapper(self: CheckGuardInputT) -> StringifyExpression:
+    def wrapper(self: CheckGuardInputT) -> list[StringifyExpression]:
         assert (
             self.tracker.is_traceable()
         ), "Cannot make guard from a non-tracable guard variable."

--- a/sot/opcode_translator/executor/variables/callable.py
+++ b/sot/opcode_translator/executor/variables/callable.py
@@ -604,14 +604,17 @@ class PaddleLayerVariable(LayerVariable):
 
     def make_stringify_guard(self) -> list[StringifyExpression]:
         if isinstance(self.tracker, CreateLayerTracker):
+            guard_variables = (
+                [self.tracker.layer_class]
+                + list(self.tracker.args)
+                + list(self.tracker.kwargs.values())
+            )
+            guard_variables = list(
+                filter(lambda var: var.tracker.is_traceable(), guard_variables)
+            )
             return reduce(
                 operator.add,
-                [self.tracker.layer_class.make_stringify_guard()]
-                + [var.make_stringify_guard() for var in self.tracker.args]
-                + [
-                    var.make_stringify_guard()
-                    for var in self.tracker.kwargs.values()
-                ],
+                [var.make_stringify_guard() for var in guard_variables],
             )
         else:
             return super().make_stringify_guard()

--- a/tests/run_all_paddle_ci.sh
+++ b/tests/run_all_paddle_ci.sh
@@ -20,9 +20,6 @@ disabled_tests=(
     ${PADDLE_TEST_BASE}/test_ptb_lm.py # There is accuracy problem of the model in SOT
     ${PADDLE_TEST_BASE}/test_ptb_lm_v2.py # There is accuracy problem of the model in SOT
     ${PADDLE_TEST_BASE}/test_cycle_gan.py # This test has a precision problem when it reaches the maximum cache size
-    # These unittests are introduced after #347, fix them later
-    ${PADDLE_TEST_BASE}/test_cpu_cuda_to_tensor.py
-    ${PADDLE_TEST_BASE}/test_to_tensor.py
 )
 
 for file in ${PADDLE_TEST_BASE}/*.py; do

--- a/tests/run_all_paddle_ci.sh
+++ b/tests/run_all_paddle_ci.sh
@@ -8,18 +8,6 @@ failed_tests=()
 disabled_tests=(
     ${PADDLE_TEST_BASE}/test_lac.py # disabled by paddle
     ${PADDLE_TEST_BASE}/test_sentiment.py # disabled unitcase by paddle
-    ${PADDLE_TEST_BASE}/test_reinforcement_learning.py # 'CartPoleEnv' object has no attribute 'seed'
-    # tmp = x
-    # for i in range(x)
-    #     tmp += Linear(x)
-    # out = paddle.grad(tmp, x)
-    # return out
-    # Because range interrupts networking, Paddle.grad cannot be networked as a standalone API.
-    # CAN BE OPEN AFTER: range is support.
-    ${PADDLE_TEST_BASE}/test_grad.py
-    ${PADDLE_TEST_BASE}/test_ptb_lm.py # There is accuracy problem of the model in SOT
-    ${PADDLE_TEST_BASE}/test_ptb_lm_v2.py # There is accuracy problem of the model in SOT
-    ${PADDLE_TEST_BASE}/test_cycle_gan.py # This test has a precision problem when it reaches the maximum cache size
 )
 
 for file in ${PADDLE_TEST_BASE}/*.py; do

--- a/tests/run_all_paddle_ci.sh
+++ b/tests/run_all_paddle_ci.sh
@@ -7,7 +7,6 @@ PADDLE_TEST_BASE=./Paddle/test/dygraph_to_static
 failed_tests=()
 disabled_tests=(
     ${PADDLE_TEST_BASE}/test_lac.py # disabled by paddle
-    ${PADDLE_TEST_BASE}/test_sentiment.py # disabled unitcase by paddle
 )
 
 for file in ${PADDLE_TEST_BASE}/*.py; do


### PR DESCRIPTION
PaddlePaddle/Paddle#57100 已合入，尝试启用 `to_tensor` 相关单测

另外其他曾经禁用掉的单测如今大多也已经支持了，均启用