### PR TITLE
add type guard to ContainerVariable

### DIFF
--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -59,12 +59,6 @@ class ContainerVariable(VariableBase):
     def make_stringify_guard(self) -> list[StringifyExpression]:
         frame_value_tracer = self.tracker.trace_value_from_frame()
 
-        type_str = {
-            list: "list",
-            tuple: "tuple",
-            range: "range",
-            dict: "dict",
-        }[type(self.init_value)]
         type_guard = StringifyExpression(
             f"isinstance({frame_value_tracer.expr}) == {self.get_py_type().__name__}",
             frame_value_tracer.free_vars,

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -60,7 +60,7 @@ class ContainerVariable(VariableBase):
         frame_value_tracer = self.tracker.trace_value_from_frame()
 
         type_guard = StringifyExpression(
-            f"isinstance({frame_value_tracer.expr}) == {self.get_py_type().__name__}",
+            f"isinstance({frame_value_tracer.expr}, {self.get_py_type().__name__})",
             frame_value_tracer.free_vars,
         )
         len_guard = StringifyExpression(

--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -39,7 +39,9 @@ class ContainerVariable(VariableBase):
         raise FallbackError('ContainerVariable.get_items do not implement')
 
     def get_wrapped_items(self):
-        raise FallbackError()
+        raise FallbackError(
+            "ContainerVariable.get_wrapped_items do not implement"
+        )
 
     def __len__(self):
         raise FallbackError('ContainerVariable.__len__ do not implement')
@@ -57,6 +59,16 @@ class ContainerVariable(VariableBase):
     def make_stringify_guard(self) -> list[StringifyExpression]:
         frame_value_tracer = self.tracker.trace_value_from_frame()
 
+        type_str = {
+            list: "list",
+            tuple: "tuple",
+            range: "range",
+            dict: "dict",
+        }[type(self.init_value)]
+        type_guard = StringifyExpression(
+            f"isinstance({frame_value_tracer.expr}) == {self.get_py_type().__name__}",
+            frame_value_tracer.free_vars,
+        )
         len_guard = StringifyExpression(
             f"len({frame_value_tracer.expr}) == {len(self.init_value)}",
             frame_value_tracer.free_vars,
@@ -77,7 +89,7 @@ class ContainerVariable(VariableBase):
             raise InnerError(f"Unsupported container type: {type(self)}")
         return reduce(
             operator.add,
-            [[len_guard]]
+            [[type_guard, len_guard]]
             + [item.make_stringify_guard() for item in guard_variables],
         )
 


### PR DESCRIPTION
此前 `ContainerVariable` 没有类型 guard，导致如下两个 case 会误命中 cache

```
x_1 = [Tensor(1), Tensor(2)]
x_2 = Tensor([1, 2])

# 根据 x_1 生成的 guard:
# len(x) == 2 and x[0].shape == [] ...
```

这种情况是无法区分两者的，因此需要增加类型 guard 确保不会错误命中