### PR TITLE
always return the CustomCode in EvalFrame callback

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import collections
 import dis
 import functools
 import inspect
@@ -10,7 +9,7 @@ import traceback
 import types
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Callable, List, Tuple
+from typing import Any, Callable, List, NamedTuple, Tuple
 
 import opcode
 
@@ -80,15 +79,17 @@ from .variables import (
     VariableFactory,
 )
 
-CustomCode = collections.namedtuple(
-    "CustomCode", ["code", "disable_eval_frame"]
-)
+
+class CustomCode(NamedTuple):
+    code: types.CodeType | None
+    disable_eval_frame: bool
 
 
 GuardedFunction = Tuple[CustomCode, Guard]
 GuardedFunctions = List[GuardedFunction]
 dummy_guard: Guard = lambda frame: True
 dummy_guard.expr = "lambda frame: True"
+FALLBACK_CUSTOM_CODE: CustomCode = CustomCode(None, False)
 
 SUPPORT_COMPARE_OP = {
     ">": operator.gt,

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -89,7 +89,7 @@ GuardedFunction = Tuple[CustomCode, Guard]
 GuardedFunctions = List[GuardedFunction]
 dummy_guard: Guard = lambda frame: True
 dummy_guard.expr = "lambda frame: True"
-FALLBACK_CUSTOM_CODE: CustomCode = CustomCode(None, False)
+FALLBACK_CUSTOM_CODE: CustomCode = CustomCode(None, True)
 
 SUPPORT_COMPARE_OP = {
     ">": operator.gt,

--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -89,7 +89,6 @@ GuardedFunction = Tuple[CustomCode, Guard]
 GuardedFunctions = List[GuardedFunction]
 dummy_guard: Guard = lambda frame: True
 dummy_guard.expr = "lambda frame: True"
-FALLBACK_CUSTOM_CODE: CustomCode = CustomCode(None, True)
 
 SUPPORT_COMPARE_OP = {
     ">": operator.gt,

--- a/sot/opcode_translator/skip_files.py
+++ b/sot/opcode_translator/skip_files.py
@@ -145,7 +145,7 @@ def need_skip(frame):
     if pycode in no_skip_code:
         return False
     if pycode in customed_skip_code:
-        log(3, f"Skip frame by code: {pycode}")
+        log(3, f"Skip frame by code: {pycode}\n")
         return True
     filename = pycode.co_filename
     if sys.version_info >= (3, 11) and filename.startswith("<frozen"):

--- a/sot/opcode_translator/transform.py
+++ b/sot/opcode_translator/transform.py
@@ -5,7 +5,11 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 from ..utils import CodeStatus, EventGuard, log, log_do
-from .executor.opcode_executor import CustomCode, InstructionTranslatorCache
+from .executor.opcode_executor import (
+    FALLBACK_CUSTOM_CODE,
+    CustomCode,
+    InstructionTranslatorCache,
+)
 from .skip_files import need_skip
 
 if TYPE_CHECKING:
@@ -44,10 +48,10 @@ def eval_frame_callback(frame, **kwargs):
     ):
         # is generator
         if frame.f_code.co_flags & 0x20 > 0:
-            return None
+            return FALLBACK_CUSTOM_CODE
 
         if need_skip(frame):
-            return None
+            return FALLBACK_CUSTOM_CODE
 
         log(
             2,

--- a/sot/opcode_translator/transform.py
+++ b/sot/opcode_translator/transform.py
@@ -42,7 +42,7 @@ def print_locals(frame):
         )
 
 
-def eval_frame_callback(frame, **kwargs):
+def eval_frame_callback(frame, **kwargs) -> CustomCode:
     with EventGuard(
         f"eval_frame_callback: {frame.f_code.co_name}", event_level=2
     ):

--- a/sot/opcode_translator/transform.py
+++ b/sot/opcode_translator/transform.py
@@ -5,11 +5,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 from ..utils import CodeStatus, EventGuard, log, log_do
-from .executor.opcode_executor import (
-    FALLBACK_CUSTOM_CODE,
-    CustomCode,
-    InstructionTranslatorCache,
-)
+from .executor.opcode_executor import CustomCode, InstructionTranslatorCache
 from .skip_files import need_skip
 
 if TYPE_CHECKING:
@@ -48,10 +44,10 @@ def eval_frame_callback(frame, **kwargs) -> CustomCode:
     ):
         # is generator
         if frame.f_code.co_flags & 0x20 > 0:
-            return FALLBACK_CUSTOM_CODE
+            return CustomCode(None, True)
 
         if need_skip(frame):
-            return FALLBACK_CUSTOM_CODE
+            return CustomCode(None, False)
 
         log(
             2,


### PR DESCRIPTION
callback 永远只返回 CustomCode，callback 返回值类型为：

```python
class CustomCode(NamedTuple):
    code: types.CodeType | None
    disable_eval_frame: bool
result: CustomCode
```

这样 PaddlePaddle/Paddle#57490 就可以清理掉 callback 返回值为 None 的逻辑了，本 PR 应该先于 PaddlePaddle/Paddle#57490 合入