### PR TITLE
fix error when call weakref

### DIFF
--- a/sot/opcode_translator/executor/variables/container.py
+++ b/sot/opcode_translator/executor/variables/container.py
@@ -888,7 +888,7 @@ class DictVariable(ContainerVariable):
             ConstantVariable(x, self.graph, ConstTracker(x))
             for x in self.proxy.get_all().keys()
         ]
-        key_list = ListVariable(raw_list, self.graph, ConstTracker(raw_list))
+        key_list = ListVariable(raw_list, self.graph, DummyTracker(raw_list))
         assert key_list is not None
         return SequenceIterVariable(
             key_list, self.graph, DummyTracker([key_list])

--- a/sot/utils/utils.py
+++ b/sot/utils/utils.py
@@ -5,6 +5,7 @@ import inspect
 import os
 import time
 import types
+import weakref
 from contextlib import contextmanager
 from enum import Enum
 from typing import Any, Generic, Iterable, Iterator, TypeVar
@@ -107,6 +108,9 @@ def is_paddle_api(func):
 
 
 def is_builtin_fn(fn):
+    special_builtin_fns = [weakref.ref]
+    if fn in special_builtin_fns:
+        return True
     if isinstance(fn, types.BuiltinFunctionType):
         return True
     for member_name, member in inspect.getmembers(builtins):

--- a/tests/test_builtin_dispatch.py
+++ b/tests/test_builtin_dispatch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import operator
 import unittest
+import weakref
 
 from test_case_base import (
     TestCaseBase,
@@ -294,6 +295,20 @@ class TestHasattr(TestCaseBase):
     def test_layer_hasattr(self):
         x = paddle.nn.Layer()
         self.assert_results(layer_hasattr, x)
+
+
+class WeakrefableObject:
+    ...
+
+
+def weakref_breakgraph(obj):
+    return weakref.ref(obj)
+
+
+class TestWeakref(TestCaseBase):
+    def test_weakref_breakgraph(self):
+        obj = WeakrefableObject()
+        self.assert_results(weakref_breakgraph, obj)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
修复 ppcls 暴露的问题

- `weakref.ref` 会当作 ClassVariable，现在将其当作 BuiltinVariable，并不实现 dispatch 目标，以触发 breakgraph

修复 ppocr 暴露的问题

- `dict.keys` 会把 key tracker 设为 ConstTracker，应为 DummyTracker