### PR TITLE
Fix local var created in loop but loop fn is in resume fn

### DIFF
--- a/sot/opcode_translator/executor/opcode_executor.py
+++ b/sot/opcode_translator/executor/opcode_executor.py
@@ -2054,8 +2054,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
             self._graph.pycode_gen.gen_store(ret_names[idx], self._code)
 
         # 3. setup vars which is created in loop
+        undefined_names = set()
         for name in loop_body_inputs[:-1]:
             if not self.has_var(name, all_used_vars[name]):
+                undefined_names.add(name)
                 self._graph.pycode_gen.gen_load_const(SotUndefinedVar())
                 self._graph.pycode_gen.gen_store(name, self._code)
 
@@ -2120,6 +2122,10 @@ class OpcodeExecutor(OpcodeExecutorBase):
         for stack_arg in self.stack:
             var_loader.load(stack_arg)
         for name in fn_inputs:
+            if not self.has_var(name) and name not in undefined_names:
+                undefined_names.add(name)
+                self._graph.pycode_gen.gen_load_const(SotUndefinedVar())
+                self._graph.pycode_gen.gen_store(name, self._code)
             self._graph.pycode_gen.gen_load(name)
 
         self._graph.pycode_gen.gen_call_function(

--- a/sot/translate.py
+++ b/sot/translate.py
@@ -81,7 +81,7 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
     def impl_sot(*args: P.args, **kwargs: P.kwargs) -> R:
         assert hasattr(
             fn, "__code__"
-        ), "Target function doesn't have code code for simulating!"
+        ), "Target function doesn't have code for simulating."
         StepInfoManager().sot_step()
         GraphLogger().clear()
         paddle.framework.core.set_eval_frame(callback)

--- a/sot/translate.py
+++ b/sot/translate.py
@@ -81,7 +81,7 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
     def impl_sot(*args: P.args, **kwargs: P.kwargs) -> R:
         assert hasattr(
             fn, "__code__"
-        ), "Target function has not code for simulating!"
+        ), "Target function doesn't have code code for simulating!"
         StepInfoManager().sot_step()
         GraphLogger().clear()
         paddle.framework.core.set_eval_frame(callback)

--- a/sot/translate.py
+++ b/sot/translate.py
@@ -81,8 +81,7 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
     def impl_sot(*args: P.args, **kwargs: P.kwargs) -> R:
         assert hasattr(
             fn, "__code__"
-        ), "Target function has not code for simulating."
-
+        ), "Target function has not code for simulating!"
         StepInfoManager().sot_step()
         GraphLogger().clear()
         paddle.framework.core.set_eval_frame(callback)

--- a/tests/test_12_for_loop.py
+++ b/tests/test_12_for_loop.py
@@ -248,6 +248,37 @@ class TestEnumerateCache(TestCaseBase):
         self.assert_nest_match(InstructionTranslatorCache().translate_count, 1)
 
 
+# after_loop_fn need zzz, and zzz is created as UndefinedVar when generating loop body
+# do not set zzz as UndefinedVar again
+def undefined_var_case_0():
+    for i in [1, 2]:
+        sot.psdb.breakgraph()
+        zzz = i
+
+    zzz = zzz + 1
+    return zzz
+
+
+# after_loop_fn need create zzz as UndefinedVar
+def undefined_var_case_1():
+    for i in [1, 2]:
+        sot.psdb.breakgraph()
+        aaa = i
+
+    for i in [1, 3]:
+        zzz = i
+    zzz = zzz + 1
+    return zzz
+
+
+class TestUndefinedVarInRiskyCodes(TestCaseBase):
+    def test_undefined_var_case_0(self):
+        self.assert_results(undefined_var_case_0)
+
+    def test_undefined_var_case_1(self):
+        self.assert_results(undefined_var_case_1)
+
+
 if __name__ == "__main__":
     with strict_mode_guard(0):
         unittest.main()


### PR DESCRIPTION
目前出现了有风险的写法，导致代码运行挂在load resume_fn 的 input，尽量让它别挂在SOT里面

现在，尝试在 resume_fn load inputs 时，及时构造 Undefined Var，但是除了loop以外，其他地方都是调用的 var_loader.load，这个接口接受 variable 作为输入而不是名字，所以不担心它是 Undefined，因此只要修改loop就可以了

loop还有一点是特别的，它会在一个new code里面调两个 resume_fn，而其他的情况只会调用一个，所以只在loop里面加了一个undefined_names = set()，因为两次调用 resume_fn 都可能需要 Undefined Var，并且一个 name 只应该被设置一次（不直接放进 executor的虚拟环境里面了，不然可能会有别的错误，毕竟UndefinedVar 它不是 variable）