### PR TITLE
don't import `sre_compile` and `sre_parse` in Python 3.11+

### DIFF
--- a/sot/opcode_translator/skip_files.py
+++ b/sot/opcode_translator/skip_files.py
@@ -20,8 +20,6 @@ import random
 import re
 import selectors
 import signal
-import sre_compile
-import sre_parse
 import sys
 import tempfile
 import threading
@@ -45,6 +43,54 @@ import paddle
 
 from ..utils import log
 
+NEED_SKIP_THIRD_PARTIY_MODULES = {
+    abc,
+    collections,
+    contextlib,
+    copy,
+    copyreg,
+    dataclasses,
+    enum,
+    functools,
+    google.protobuf,
+    importlib,
+    inspect,
+    linecache,
+    logging,
+    multiprocessing,
+    numpy,
+    operator,
+    os,
+    posixpath,
+    random,
+    re,
+    selectors,
+    signal,
+    tempfile,
+    threading,
+    tokenize,
+    traceback,
+    types,
+    typing,
+    unittest,
+    weakref,
+    _collections_abc,
+    _weakrefset,
+    decorator,
+    codecs,
+    uuid,
+    setuptools,
+    distutils,
+    warnings,
+}
+
+if sys.version_info < (3, 11):
+    import sre_compile
+    import sre_parse
+
+    NEED_SKIP_THIRD_PARTIY_MODULES.add(sre_compile)
+    NEED_SKIP_THIRD_PARTIY_MODULES.add(sre_parse)
+
 
 def _strip_init_py(s):
     return re.sub(r"__init__.py$", "", s)
@@ -54,51 +100,7 @@ def _module_dir(m: types.ModuleType):
     return _strip_init_py(m.__file__)
 
 
-skip_file_names = {
-    _module_dir(m)
-    for m in (
-        abc,
-        collections,
-        contextlib,
-        copy,
-        copyreg,
-        dataclasses,
-        enum,
-        functools,
-        google.protobuf,
-        importlib,
-        inspect,
-        linecache,
-        logging,
-        multiprocessing,
-        numpy,
-        operator,
-        os,
-        posixpath,
-        random,
-        re,
-        selectors,
-        sre_compile,
-        sre_parse,
-        signal,
-        tempfile,
-        threading,
-        tokenize,
-        traceback,
-        types,
-        typing,
-        unittest,
-        weakref,
-        _collections_abc,
-        _weakrefset,
-        decorator,
-        codecs,
-        uuid,
-        setuptools,
-        distutils,
-        warnings,
-    )
-}
+skip_file_names = {_module_dir(m) for m in NEED_SKIP_THIRD_PARTIY_MODULES}
 
 
 sot_path = os.path.dirname(__file__).rpartition("/")[0] + "/"


### PR DESCRIPTION
Paddle 目前会通过 `re` 间接使用 `sre_compile` 和 `sre_parse`，因此我们需要将它们 skip 掉，而 skip 依赖于 import 他们，而它们已经在 3.11 deprecated 了[^1]，这会导致用户使用 3.11 第一次 import paddle 时会弹出两个 deprecated warning，非常影响体验

为避免这个问题，3.11 不再 import 这两个模块，而且 3.11 的 `re` 也不会间接使用它们了，因此也不需要 skip 它们

[^1]: https://docs.python.org/3/whatsnew/3.11.html#modules