### PR TITLE
fallback when function has error handling

### DIFF
--- a/sot/opcode_translator/transform.py
+++ b/sot/opcode_translator/transform.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dis
+import sys
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -45,6 +46,14 @@ def eval_frame_callback(frame, **kwargs) -> CustomCode:
         # is generator
         if frame.f_code.co_flags & 0x20 > 0:
             return CustomCode(None, True)
+
+        # NOTE(SigureMo): Temporary fallback when code has exception handling.
+        if sys.version_info >= (3, 11) and frame.f_code.co_exceptiontable:
+            log(
+                3,
+                f"[eval_frame_callback] {frame.f_code} has co_exceptiontable\n",
+            )
+            return CustomCode(None, False)
 
         if need_skip(frame):
             log(3, f"[eval_frame_callback] skip {frame.f_code}\n")

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,5 +1,7 @@
 import unittest
 
+from test_case_base import TestCaseBase, strict_mode_guard
+
 import sot
 
 
@@ -10,11 +12,13 @@ def fn_with_try_except():
         raise ValueError("ValueError")
     except ValueError:
         print("catch ValueError")
+        return True
 
 
-class TestErrorHandling(unittest.TestCase):
+class TestErrorHandling(TestCaseBase):
+    @strict_mode_guard(0)
     def test_fn_with_try_except(self):
-        sot.symbolic_translate(fn_with_try_except)()
+        self.assert_results(fn_with_try_except)
 
 
 if __name__ == "__main__":

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,21 @@
+import unittest
+
+import sot
+
+
+def fn_with_try_except():
+    sot.psdb.breakgraph()
+    sot.psdb.fallback()
+    try:
+        raise ValueError("ValueError")
+    except ValueError:
+        print("catch ValueError")
+
+
+class TestErrorHandling(unittest.TestCase):
+    def test_fn_with_try_except(self):
+        sot.symbolic_translate(fn_with_try_except)()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
因为 Python 3.11 没有对 exceptiontable 进行处理，因此当发生 breakgraph 后生成的代码里是可能包含 exceptiontable 的，且是直接从 origin code copy 的，直接 copy 的是不对的，这会导致 breakgraph 后的 resume 函数无法正常捕获 error

目前我们对这种情况直接 fallback，以确保错误能够正确捕获，在之后再实现 exceptiontable 的生成