### PR TITLE
align codestyle to paddle

### DIFF
--- a/.github/workflows/paddle_ci.yaml
+++ b/.github/workflows/paddle_ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Increase swapfile
         run: |
           sudo swapoff -a
-          sudo fallocate -l 15G /swapfile
+          sudo fallocate -l 8G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile

--- a/sot/__init__.py
+++ b/sot/__init__.py
@@ -1,12 +1,8 @@
 from . import psdb  # noqa: F401
-from .opcode_translator.breakpoint import BM, add_breakpoint, add_event
-from .opcode_translator.skip_files import skip_function
-from .translate import symbolic_translate
-
-__all__ = [
-    "symbolic_translate",
-    "add_breakpoint",
-    "add_event",
-    "BM",
-    "skip_function",
-]
+from .opcode_translator.breakpoint import (  # noqa: F401
+    BM,
+    add_breakpoint,
+    add_event,
+)
+from .opcode_translator.skip_files import skip_function  # noqa: F401
+from .translate import symbolic_translate  # noqa: F401

--- a/sot/opcode_translator/__init__.py
+++ b/sot/opcode_translator/__init__.py
@@ -1,3 +1,1 @@
-from .transform import eval_frame_callback
-
-__all__ = ["eval_frame_callback"]
+from .transform import eval_frame_callback  # noqa: F401

--- a/sot/opcode_translator/instruction_utils/__init__.py
+++ b/sot/opcode_translator/instruction_utils/__init__.py
@@ -1,4 +1,4 @@
-from .instruction_utils import (
+from .instruction_utils import (  # noqa: F401
     Instruction,
     calc_offset_from_bytecode_offset,
     calc_stack_effect,
@@ -13,27 +13,8 @@ from .instruction_utils import (
     replace_instr,
     reset_offset,
 )
-from .opcode_analysis import (
+from .opcode_analysis import (  # noqa: F401
     Space,
     analysis_inputs,
     analysis_used_names_with_space,
 )
-
-__all__ = [
-    "analysis_inputs",
-    "analysis_used_names_with_space",
-    "calc_offset_from_bytecode_offset",
-    "calc_stack_effect",
-    "Instruction",
-    "convert_instruction",
-    "gen_instr",
-    "get_instructions",
-    "modify_instrs",
-    "modify_vars",
-    "reset_offset",
-    "relocate_jump_target",
-    "modify_extended_args",
-    "replace_instr",
-    "instrs_info",
-    "Space",
-]

--- a/sot/symbolic/interpreter.py
+++ b/sot/symbolic/interpreter.py
@@ -168,7 +168,7 @@ def prepare_state(SIR, inputs):
     state = {}
 
     # update free vars if exsits
-    if SIRRuntimeCache().has_key(SIR.name):
+    if SIRRuntimeCache().has_key(SIR.name):  # noqa: W601
         free_var_seeker = SIRRuntimeCache().get_free_vars(SIR.name)
         if free_var_seeker:
             state = free_var_seeker()

--- a/sot/utils/__init__.py
+++ b/sot/utils/__init__.py
@@ -1,18 +1,18 @@
-from .code_status import CodeStatus
-from .exceptions import (
+from .code_status import CodeStatus  # noqa: F401
+from .exceptions import (  # noqa: F401
     BreakGraphError,
     FallbackError,
     InnerError,
     inner_error_default_handler,
 )
-from .magic_methods import magic_method_builtin_dispatch
-from .paddle_api_config import (
+from .magic_methods import magic_method_builtin_dispatch  # noqa: F401
+from .paddle_api_config import (  # noqa: F401
     is_break_graph_tensor_methods,
     is_inplace_api,
     paddle_tensor_methods,
 )
-from .SotProfiler import EventGuard, SotProfiler, event_register
-from .utils import (
+from .SotProfiler import EventGuard, SotProfiler, event_register  # noqa: F401
+from .utils import (  # noqa: F401
     Cache,
     GraphLogger,
     NameGenerator,
@@ -47,52 +47,3 @@ from .utils import (
     show_trackers,
     tmp_name_guard,
 )
-
-__all__ = [
-    "InnerError",
-    "FallbackError",
-    "BreakGraphError",
-    "Singleton",
-    "NameGenerator",
-    "OrderedSet",
-    'inner_error_default_handler',
-    "log",
-    "log_do",
-    "no_eval_frame",
-    "is_builtin_fn",
-    "is_paddle_api",
-    "in_paddle_module",
-    "is_break_graph_api",
-    'is_break_graph_tensor_methods',
-    "map_if",
-    "map_if_extend",
-    "flatten_extend",
-    "count_if",
-    "Cache",
-    "execute_time",
-    "magic_method_builtin_dispatch",
-    "meta_str",
-    "is_strict_mode",
-    "is_clean_code",
-    "paddle_tensor_methods",
-    "ResumeFnNameFactory",
-    "list_contain_by_id",
-    "list_find_index_by_id",
-    "show_trackers",
-    "get_unbound_method",
-    "GraphLogger",
-    "SotUndefinedVar",
-    "event_register",
-    "EventGuard",
-    "SotProfiler",
-    "hashable",
-    "is_inplace_api",
-    "sotprof_range",
-    "min_graph_size",
-    "CodeStatus",
-    "cost_model",
-    "StepInfoManager",
-    "StepState",
-    "tmp_name_guard",
-    "current_tmp_name_records",
-]


### PR DESCRIPTION
将 codestyle 对齐 Paddle，以便直接 copy 代码即可 merge

- 移除 `__all__`，避免在 Paddle 暴露成 public API
- 添加一个 `noqa: W601`，这是因为 ruff 和 flake8 差异导致的，暂时对齐 Paddle 的 flake8 行为，在之后 Paddle 也使用 ruff，并引入 RUF100 后会自动移除